### PR TITLE
Client Cognito Authentication

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,8 @@ classifiers =
 
 [options]
 install_requires =
+    boto3
+    boto3-stubs[apigateway,cognito,essential]
     requests>=2.23
     PyYAML~=6.0
     types-PyYAML~=6.0

--- a/src/pds/ingress/authorizer/README.md
+++ b/src/pds/ingress/authorizer/README.md
@@ -1,0 +1,37 @@
+# Authorizer Function for use with the DUM API Gateway
+
+This is a token-based authorizer function to allow only JWT access tokens issued for the client IDs of the Unity Cognito
+user pool.
+
+The version was adapted for the DUM from the sample version provided by Unity, found [here](https://github.com/unity-sds/unity-cs-security/tree/main/code_samples/api-gateway-common-lambda-authorizer-function).
+
+The JWT access token is verified using the [aws-jwt-verify](https://github.com/awslabs/aws-jwt-verify) JavaScript library developed by the AWS Labs .
+
+This authorizer can be used to verify JWT access tokens issued for multiple client IDs, presented as a
+comma separated list. It is possible to support the verification of JWTs issued by multiple user pools also, as explained in [Trusting multiple User Pools](https://github.com/awslabs/aws-jwt-verify#trusting-multiple-user-pools).
+
+### Steps to use this lambda authorizer function:
+
+1. Execute the following command to get the npm modules (make sure that you have [npm setup](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) in your computer before this step)
+
+```shell
+npm install
+```
+
+2. Create a deployment package as a ZIP file.
+
+```shell
+zip -r dum-lambda-auth.zip .
+```
+
+3. Create a lambda function on AWS as explained in https://docs.aws.amazon.com/lambda/latest/dg/getting-started.html
+
+4. Deploy the previously created ZIP file as explained in https://docs.aws.amazon.com/lambda/latest/dg/gettingstarted-package.html#gettingstarted-package-zip
+
+5. After deploying the lambda function, go to the lambda function in AWS Console and  click on Configuration -> Environment variables.
+
+6. Configure the following 2 environment variables
+   * COGNITO_USER_POOL_ID = <COGNITO_USER_POOL_ID>
+   * COGNITO_CLIENT_ID_LIST = <COMMA_SEPERATED_LIST_OF_CLIENT_IDS>
+
+After above steps, the lambda functions can be used in API Gateway Authorizers.

--- a/src/pds/ingress/authorizer/index.js
+++ b/src/pds/ingress/authorizer/index.js
@@ -1,0 +1,127 @@
+/**
+ * Token-based lambda authorizer function to allow only JWT access tokens issued for the user pool
+ * configured as lambda environment variable COGNITO_USER_POOL_ID and the list of
+ * client ids configured as lambda environment variable COGNITO_CLIENT_ID_LIST.
+ *
+ * Note: Please make sure to configure COGNITO_USER_POOL_ID and COGNITO_CLIENT_ID_LIST
+ * environment variable for this lambda.
+ *
+ */
+
+/**
+ * Verifies a JWT token and check Cognito groups.
+ *
+ * The JWT access token is verified using the aws-jwt-verify  JavaScript library developed by the AWS Labs.
+ *
+ * References:
+ * https://docs.aws.amazon.com/cognito/latest/developerguide/amazon-cognito-user-pools-using-tokens-verifying-a-jwt.html
+ * https://auth0.com/docs/secure/tokens/json-web-tokens/validate-json-web-tokens
+ * https://docs.aws.amazon.com/cognito/latest/developerguide/amazon-cognito-user-pools-using-tokens-verifying-a-jwt.html
+ * https://github.com/awslabs/aws-jwt-verify
+ *
+ */
+exports.handler =  async(event, _context, callback) => {
+    let token = event.authorizationToken;
+    console.log(token);
+
+    let accessToken;
+
+    if (token.startsWith("Bearer")) {
+        accessToken = token.split(' ')[1];
+        console.log("accessToken =" + accessToken);
+    } else {
+        console.log("Token not valid! Does not start with Bearer.");
+        callback("Unauthorized");
+    }
+
+    // Use the aws-jwt-verify
+    const { CognitoJwtVerifier } = require("aws-jwt-verify");
+
+    // Create a verifier that expects valid access tokens from COGNITO_USER_POOL_ID and COGNITO_CLIENT_ID_LIST
+    const verifier = CognitoJwtVerifier.create({
+        userPoolId: process.env.COGNITO_USER_POOL_ID,
+        tokenUse: "access",
+        clientId: process.env.COGNITO_CLIENT_ID_LIST.split(',').map(item=>item.trim()),
+    });
+
+    // Conduct verification
+    try {
+        const payload = await verifier.verify(accessToken);
+        console.log("Token is valid. Payload:", payload);
+    } catch (error) {
+        console.log("Token not valid!");
+        console.log(error);
+        callback("Unauthorized");
+    }
+
+    // Check user groups
+    let decoded;
+
+    try {
+        decoded = parseJwt(token);
+
+    } catch (error) {
+        console.log(error);
+        callback("Unauthorized");
+    }
+
+    console.log(decoded);
+
+    let groups = decoded['cognito:groups'];
+    console.log(groups);
+
+    if (groups.includes("PDS_DUM_USERS")) {
+        console.log("VALID TOKEN, ALLOW!!")
+        callback(null, generatePolicy('user', 'Allow', event.methodArn));
+    } else {
+        callback("Unauthorized");
+    }
+
+};
+
+
+/**
+ * Parses a JWT token.
+ */
+function parseJwt (token) {
+    let base64Url = token.split('.')[1];
+    let base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+    let jsonPayload = decodeURIComponent(decode(base64).split('').map(function(c) {
+        return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2);
+    }).join(''));
+
+    return JSON.parse(jsonPayload);
+}
+
+
+/**
+ * Decodes a base 64 encoded string.
+ */
+function decode(base64Encoded) {
+    let converted = Buffer.from(base64Encoded, 'base64').toString()
+    console.log(converted);
+    return converted;
+}
+
+/**
+ * Helper function to generate an IAM policy.
+ */
+let generatePolicy = function(principalId, effect, resource) {
+    let authResponse = {};
+
+    authResponse.principalId = principalId;
+
+    if (effect && resource) {
+        var policyDocument = {};
+        policyDocument.Version = '2012-10-17';
+        policyDocument.Statement = [];
+        var statementOne = {};
+        statementOne.Action = 'execute-api:Invoke';
+        statementOne.Effect = effect;
+        statementOne.Resource = resource;
+        policyDocument.Statement[0] = statementOne;
+        authResponse.policyDocument = policyDocument;
+    }
+
+    return authResponse;
+};

--- a/src/pds/ingress/authorizer/package-lock.json
+++ b/src/pds/ingress/authorizer/package-lock.json
@@ -1,0 +1,262 @@
+{
+  "name": "lambda-auth",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "lambda-auth",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@types/atob": "^2.1.2",
+        "aws-jwt-verify": "^3.0.0",
+        "jsonwebtoken": "^8.5.1"
+      }
+    },
+    "node_modules/@types/atob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@types/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-8GAYQ1jDRUQkSpHzJUqXwAkYFOxuWAOGLhIR4aPd/Y/yL12Q/9m7LsKpHKlfKdNE/362Hc9wPI1Yh6opDfxVJg=="
+    },
+    "node_modules/aws-jwt-verify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/aws-jwt-verify/-/aws-jwt-verify-3.0.0.tgz",
+      "integrity": "sha512-omrsipeveHvc2L7WaoSZIS0hozRoqKsGeaWYxbqKl1ZTAjL7TKCVqYp0Gy0G0juV4Nr6niTYSNqnW4NJHXACbw==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=4",
+        "npm": ">=1.4.28"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "dependencies": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    }
+  },
+  "dependencies": {
+    "@types/atob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@types/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-8GAYQ1jDRUQkSpHzJUqXwAkYFOxuWAOGLhIR4aPd/Y/yL12Q/9m7LsKpHKlfKdNE/362Hc9wPI1Yh6opDfxVJg=="
+    },
+    "aws-jwt-verify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/aws-jwt-verify/-/aws-jwt-verify-3.0.0.tgz",
+      "integrity": "sha512-omrsipeveHvc2L7WaoSZIS0hozRoqKsGeaWYxbqKl1ZTAjL7TKCVqYp0Gy0G0juV4Nr6niTYSNqnW4NJHXACbw=="
+    },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+    },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "jsonwebtoken": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+      "requires": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^5.6.0"
+      }
+    },
+    "jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "requires": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "requires": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+    },
+    "lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+    },
+    "lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+    },
+    "lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+    },
+    "lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
+    },
+    "ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
+    "semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+    }
+  }
+}

--- a/src/pds/ingress/authorizer/package.json
+++ b/src/pds/ingress/authorizer/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "lambda-auth",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@types/atob": "^2.1.2",
+    "jsonwebtoken": "^8.5.1",
+    "aws-jwt-verify": "^3.0.0"
+  }
+}

--- a/src/pds/ingress/util/auth_util.py
+++ b/src/pds/ingress/util/auth_util.py
@@ -1,0 +1,91 @@
+"""
+============
+auth_util.py
+============
+
+Module containing functions for performing user authentication to the
+Ingress Service Lambda.
+
+"""
+import logging
+
+import boto3  # type: ignore
+
+logger = logging.getLogger(__name__)
+
+
+class AuthUtil:
+    """
+    Class used to roll up methods related to user authentication to the
+    Ingress Service Lambda.
+    """
+
+    @staticmethod
+    def perform_cognito_authentication(cognito_config):
+        """
+        Authenticates the current user of the Upload Service to AWS Cognito
+        based on the settings of the Cognito portion of the INI config.
+
+        Parameters
+        ----------
+        cognito_config : dict
+            The COGNITO portion of the parsed INI config, containing configuration
+            details such as the username and password to authenticate with.
+
+        Returns
+        -------
+        authentication_result : dict
+            Dictionary containing the results of a successful Cognito
+            authentication, including the Access Token.
+
+        Raises
+        ------
+        RuntimeError
+            If authentication fails for any reason.
+
+        """
+        client = boto3.client("cognito-idp", region_name=cognito_config["region"])
+
+        auth_params = {"USERNAME": cognito_config["username"], "PASSWORD": cognito_config["password"]}
+
+        logger.info(f"Performing Cognito authentication for user {cognito_config['username']}")
+
+        try:
+            response = client.initiate_auth(
+                AuthFlow="USER_PASSWORD_AUTH", AuthParameters=auth_params, ClientId=cognito_config["client_id"]
+            )
+        except Exception as err:
+            raise RuntimeError(f"Failed to authenticate to Cognito, reason: {str(err)}") from err
+
+        logger.info("Authentication successful")
+
+        authentication_result = response["AuthenticationResult"]
+
+        return authentication_result
+
+    @staticmethod
+    def create_bearer_token(authentication_result):
+        """
+        Formats a Bearer token from a successful AWS Cognito authentication
+        result.
+
+        Parameters
+        ----------
+        authentication_result : dict
+            Dictionary containing the results of a successful Cognito
+            authentication, including the Access Token.
+
+        Returns
+        -------
+        bearer_token : str
+            A Bearer token suitable for use with an Authentication header in
+            an HTTP request.
+
+        """
+        logger.info("Creating Bearer token")
+
+        access_token = authentication_result["AccessToken"]
+
+        bearer_token = f"Bearer {access_token}"
+
+        return bearer_token

--- a/src/pds/ingress/util/conf.default.ini
+++ b/src/pds/ingress/util/conf.default.ini
@@ -9,5 +9,11 @@ region       = us-west-2
 stage        = test
 resource     = request
 
+[COGNITO]
+client_id    = 123456789
+username     = cognito_user
+password     = cognito_pass
+region       = us-west-2
+
 [OTHER]
 log_level = INFO

--- a/tests/pds/ingress/util/test_auth_util.py
+++ b/tests/pds/ingress/util/test_auth_util.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+import unittest
+from unittest.mock import patch
+
+import pds.ingress.util.auth_util
+from pds.ingress.util.auth_util import AuthUtil
+
+
+class MockCognitoClient:
+    """Mock implementation for the boto3 Cognito client class"""
+
+    def initiate_auth(self, AuthFlow, AuthParameters, ClientId):
+        """Simulate an authentication attempt"""
+        if AuthParameters["PASSWORD"] == "good_pass":
+            return {"AuthenticationResult": AuthUtilTest.authentication_result}
+        else:
+            raise Exception("Incorrect username or password.")
+
+
+def mock_boto3_client(*args, **kwargs):
+    """Mock implementation for boto3.client to always return the Mock Cognito client class"""
+    return MockCognitoClient()
+
+
+class AuthUtilTest(unittest.TestCase):
+    authentication_result = {}
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        # Create a dummy authentication result from Cognito
+        cls.authentication_result = {
+            "AccessToken": "123abc",
+            "ChallengeParameters": {},
+            "ExpiresIn": 3600,
+            "IdToken": "456ijk",
+            "RefreshToken": "789xyz",
+            "TokenType": "Bearer",
+        }
+
+    @patch.object(
+        pds.ingress.util.auth_util.boto3,
+        "client",
+        mock_boto3_client,
+    )
+    def test_perform_cognito_authentication(self):
+        """Tests for AuthUtil.perform_cognito_authentication"""
+        # Test with a dummy Cognito configuration containing a "valid" username and password
+        cognito_config = {
+            "username": "cognito_user",
+            "password": "good_pass",
+            "client_id": "cognito_client_id",
+            "region": "cognito_region",
+        }
+
+        authentication_result = AuthUtil.perform_cognito_authentication(cognito_config)
+
+        self.assertIsInstance(authentication_result, dict)
+        self.assertDictEqual(authentication_result, self.authentication_result)
+
+        # Retry with "invalid" credentials
+        cognito_config["password"] = "bad_pass"
+
+        with self.assertRaises(
+            RuntimeError, msg="Failed to authenticate to Cognito, reason: Incorrect username or password."
+        ):
+            AuthUtil.perform_cognito_authentication(cognito_config)
+
+    def test_create_bearer_token(self):
+        """Tests for AuthUtil.create_bearer_token"""
+        bearer_token = AuthUtil.create_bearer_token(self.authentication_result)
+
+        self.assertIsInstance(bearer_token, str)
+        self.assertTrue(bearer_token.startswith("Bearer"))
+
+        access_token = bearer_token.split(" ")[-1]
+
+        self.assertEqual(access_token, self.authentication_result["AccessToken"])

--- a/tests/pds/ingress/util/test_config_util.py
+++ b/tests/pds/ingress/util/test_config_util.py
@@ -19,6 +19,11 @@ class ConfigUtilTest(unittest.TestCase):
         self.assertEqual(parser["API_GATEWAY"]["stage"], "test")
         self.assertEqual(parser["API_GATEWAY"]["resource"], "request")
 
+        self.assertEqual(parser["COGNITO"]["client_id"], "123456789")
+        self.assertEqual(parser["COGNITO"]["username"], "cognito_user")
+        self.assertEqual(parser["COGNITO"]["password"], "cognito_pass")
+        self.assertEqual(parser["COGNITO"]["region"], "us-west-2")
+
         self.assertEqual(parser["OTHER"]["log_level"], "INFO")
 
 


### PR DESCRIPTION
## 🗒️ Summary
This PR integrates support for performing a user authentication step in the Ingress Client script prior to accessing the API gateway. The client now utilizes user credentials within the INI config to obtain a Bearer token from an AWS Cognito instance (the Cognito client ID is also configured via INI). If authentication is successful, the Bearer token is included with the request to API Gateway to satisfy the Lambda Authorizer function now attached to the Gateway. 

## ⚙️ Test Data and/or Report
One of the following should be included here:
- The unit test module for the config parser has been updated for the new COGNITO section
- A unit test module has been added for the new utils.auth_util.py module

## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->
Resolves #16 

