### PR TITLE
User Group Authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,10 @@
 #
 # Items for Git to ignore
 
+# Package specific
+src/pds/ingress/authorizer/node_modules
+src/pds/ingress/authorizer/*.zip
+
 # Python build, virtual environments, and buildouts
 venv
 __pycache__/

--- a/scripts/pds-ingress-client.py
+++ b/scripts/pds-ingress-client.py
@@ -62,6 +62,7 @@ def request_file_for_ingress(ingress_file_path, node_id, api_gateway_config, bea
     params = {"node": node_id, "node_name": NodeUtil.node_id_to_long_name[node_id]}
     payload = {"url": ingress_file_path}
     headers = {"Authorization": bearer_token,
+               "UserGroup": NodeUtil.node_id_to_group_name(node_id),
                "content-type": "application/json",
                "x-amz-docs-region": api_gateway_region}
 

--- a/scripts/pds-ingress-client.py
+++ b/scripts/pds-ingress-client.py
@@ -72,13 +72,11 @@ def request_file_for_ingress(ingress_file_path, node_id, api_gateway_config, bea
         )
         response.raise_for_status()
     except requests.exceptions.HTTPError as err:
-        raise RuntimeError(f"Ingress request failed, reason: {str(err)}")
+        raise RuntimeError(f"Ingress request failed, reason: {str(err)}") from err
 
     logger.debug(f'Raw content returned from request: {response.text}')
 
-    json_response = response.json()
-
-    s3_ingress_uri = json.loads(json_response["body"])
+    s3_ingress_uri = json.loads(response.text)
 
     logger.info(f"S3 URI for request: {s3_ingress_uri}")
 

--- a/src/pds/ingress/authorizer/index.js
+++ b/src/pds/ingress/authorizer/index.js
@@ -24,13 +24,10 @@
  */
 exports.handler = async(event, _context, callback) => {
     let token = event.headers.Authorization;
-    console.log(token);
-
     let accessToken;
 
     if (token.startsWith("Bearer")) {
         accessToken = token.split(' ')[1];
-        console.log("accessToken =" + accessToken);
     } else {
         console.log("Token not valid! Does not start with Bearer.");
         callback("Unauthorized");
@@ -67,10 +64,7 @@ exports.handler = async(event, _context, callback) => {
         callback("Unauthorized");
     }
 
-    console.log(decoded);
-
     let groups = decoded['cognito:groups'];
-    console.log(groups);
 
     let request_group = event.headers.UserGroup;
 
@@ -104,7 +98,6 @@ function parseJwt (token) {
  */
 function decode(base64Encoded) {
     let converted = Buffer.from(base64Encoded, 'base64').toString()
-    console.log(converted);
     return converted;
 }
 

--- a/src/pds/ingress/service/pds_ingress_app.py
+++ b/src/pds/ingress/service/pds_ingress_app.py
@@ -98,8 +98,9 @@ def lambda_handler(event, context):
     bucket_map = initialize_bucket_map()
 
     # Parse request details from event object
-    local_url = event.get("url")
-    request_node = event.get("node")
+    body = json.loads(event["body"])
+    local_url = body.get("url")
+    request_node = event["queryStringParameters"].get("node")
 
     if not local_url or not request_node:
         raise RuntimeError("Both a local URL and request Node ID must be provided")

--- a/src/pds/ingress/util/node_util.py
+++ b/src/pds/ingress/util/node_util.py
@@ -30,3 +30,11 @@ class NodeUtil:
     def permissible_node_ids(cls):
         """Returns a list of the Node IDs accepted by the Ingress client"""
         return cls.node_id_to_long_name.keys()
+
+    @classmethod
+    def node_id_to_group_name(cls, node_id):
+        """Returns the Cognito group name for the given node ID"""
+        if node_id.lower() not in cls.node_id_to_long_name.keys():
+            raise ValueError(f'Unknown node ID "{node_id}"')
+
+        return f"PDS_{node_id.upper()}_USERS"

--- a/tests/pds/ingress/service/test_pds_ingress_app.py
+++ b/tests/pds/ingress/service/test_pds_ingress_app.py
@@ -67,7 +67,10 @@ class PDSIngressAppTest(unittest.TestCase):
 
     def test_lambda_handler(self):
         """Test the lambda_handler function with the default bucket map"""
-        test_event = {"url": "gbo.ast.catalina.survey/bundle_gbo.ast.catalina.survey_v1.0.xml", "node": "sbn"}
+        test_event = {
+            "body": json.dumps({"url": "gbo.ast.catalina.survey/bundle_gbo.ast.catalina.survey_v1.0.xml"}),
+            "queryStringParameters": {"node": "sbn"},
+        }
 
         context = {}  # Unused by lambda_handler
 
@@ -84,7 +87,10 @@ class PDSIngressAppTest(unittest.TestCase):
 
         self.assertEqual(response_body, expected_body)
 
-        test_event = {"url": "some.other.survey/bundle.some.other.survey_v1.0.xml", "node": "sbn"}
+        test_event = {
+            "body": json.dumps({"url": "some.other.survey/bundle.some.other.survey_v1.0.xml"}),
+            "queryStringParameters": {"node": "sbn"},
+        }
 
         response = lambda_handler(test_event, context)
 
@@ -93,12 +99,15 @@ class PDSIngressAppTest(unittest.TestCase):
 
         self.assertEqual(response_body, expected_body)
 
-        test_event = {"url": "gbo.ast.catalina.survey/bundle_gbo.ast.catalina.survey_v1.0.xml", "node": "unk"}
+        test_event = {
+            "body": json.dumps({"url": "gbo.ast.catalina.survey/bundle_gbo.ast.catalina.survey_v1.0.xml"}),
+            "queryStringParameters": {"node": "unk"},
+        }
 
         with self.assertRaises(RuntimeError, msg="No bucket map entries configured for Node ID unk"):
             lambda_handler(test_event, context)
 
-        test_event = {"node": "eng"}
+        test_event = {"body": json.dumps({}), "queryStringParameters": {"node": "eng"}}
 
         with self.assertRaises(RuntimeError, msg="Both a local URL and request Node ID must be provided"):
             lambda_handler(test_event, context)


### PR DESCRIPTION
## 🗒️ Summary
This branch adds support for user group authentication within the Cognito Lambda authorizer function used with the Ingress API gateway. A user's requesting group is now determined based on the PDS node identifier used to submit an ingress request. This group must be among the Cognito groups within a decoded access token to allow the ingress request through to the API gateway. This ensures that users cannot act on behalf of PDS nodes that they do not belong to.

## ⚙️ Test Data and/or Report
One of the following should be included here:
* Unit tests have been updated to reflect the change from a "non-proxy" Lambda integration to a "proxy" integration with API gateway.

## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->
Resolves #18 


