### PR TITLE
Client logging to CloudWatch

### DIFF
--- a/scripts/pds-ingress-client.py
+++ b/scripts/pds-ingress-client.py
@@ -9,7 +9,7 @@ import pds.ingress.util.log_util as log_util
 
 from pds.ingress.util.auth_util import AuthUtil
 from pds.ingress.util.config_util import ConfigUtil
-from pds.ingress.util.log_util import get_logger
+from pds.ingress.util.log_util import get_logger, get_log_level
 from pds.ingress.util.node_util import NodeUtil
 from pds.ingress.util.path_util import PathUtil
 
@@ -158,6 +158,11 @@ def setup_argparser():
     parser.add_argument('--dry-run', action='store_true',
                         help='Derive the full set of ingress paths without '
                              'performing any submission requests to the server.')
+    parser.add_argument('--log-level', '-l', type=str, default=None,
+                        choices=["warn", "warning", "info", "debug"],
+                        help="Sets the Logging level for logged messages. If not "
+                             "provided, the logging level set in the INI config "
+                             "is used instead.")
     parser.add_argument('ingress_paths', type=str, nargs='+',
                         metavar='file_or_dir',
                         help='One or more paths to the files to ingest to S3. '
@@ -184,7 +189,7 @@ def main():
 
     config = ConfigUtil.get_config(args.config_path)
 
-    logger = get_logger(__name__)
+    logger = get_logger(__name__, log_level=get_log_level(args.log_level))
 
     logger.info(f"Loaded config file {args.config_path}")
 

--- a/scripts/pds-ingress-client.py
+++ b/scripts/pds-ingress-client.py
@@ -2,16 +2,16 @@
 
 import argparse
 import json
-import logging
 import requests
 import subprocess
 
+import pds.ingress.util.log_util as log_util
+
 from pds.ingress.util.auth_util import AuthUtil
 from pds.ingress.util.config_util import ConfigUtil
+from pds.ingress.util.log_util import get_logger
 from pds.ingress.util.node_util import NodeUtil
 from pds.ingress.util.path_util import PathUtil
-
-logger = logging.getLogger(__name__)
 
 
 def request_file_for_ingress(ingress_file_path, node_id, api_gateway_config, bearer_token):
@@ -43,6 +43,8 @@ def request_file_for_ingress(ingress_file_path, node_id, api_gateway_config, bea
         If the request to the Ingress Service fails.
 
     """
+    logger = get_logger(__name__)
+
     logger.info(f"Requesting ingress of file {ingress_file_path} for node ID {node_id}")
 
     # Extract the API Gateway configuration params
@@ -74,8 +76,6 @@ def request_file_for_ingress(ingress_file_path, node_id, api_gateway_config, bea
     except requests.exceptions.HTTPError as err:
         raise RuntimeError(f"Ingress request failed, reason: {str(err)}") from err
 
-    logger.debug(f'Raw content returned from request: {response.text}')
-
     s3_ingress_uri = json.loads(response.text)
 
     logger.info(f"S3 URI for request: {s3_ingress_uri}")
@@ -101,6 +101,8 @@ def ingress_file_to_s3(ingress_file_path, s3_ingress_uri):
         If the S3 upload fails for any reason.
 
     """
+    logger = get_logger(__name__)
+
     logger.info(f"Ingesting {ingress_file_path} to {s3_ingress_uri}")
 
     result = subprocess.run(
@@ -176,14 +178,15 @@ def main():
         and dry-run is not enabled.
 
     """
-    # TODO: create module to perform logger setup based on INI setting/user arg
-    logging.basicConfig(level=logging.DEBUG)
-
     parser = setup_argparser()
 
     args = parser.parse_args()
 
     config = ConfigUtil.get_config(args.config_path)
+
+    logger = get_logger(__name__)
+
+    logger.info(f"Loaded config file {args.config_path}")
 
     # Derive the full list of ingress paths based on the set of paths requested
     # by the user
@@ -204,6 +207,11 @@ def main():
 
         bearer_token = AuthUtil.create_bearer_token(authentication_result)
 
+        # Set the bearer token on the CloudWatchHandler singleton, so it can
+        # be used to authenticate submissions to the CloudWatch Logs API endpoint
+        log_util.CLOUDWATCH_HANDLER.bearer_token = bearer_token
+        log_util.CLOUDWATCH_HANDLER.node_id = node_id
+
         for resolved_ingress_path in resolved_ingress_paths:
             # Remove path prefix if one was configured
             trimmed_path = PathUtil.trim_ingress_path(resolved_ingress_path, args.prefix)
@@ -213,6 +221,9 @@ def main():
             )
 
             ingress_file_to_s3(resolved_ingress_path, s3_ingress_uri)
+
+        # Flush all logged statements to CloudWatch Logs
+        log_util.CLOUDWATCH_HANDLER.flush()
     else:
         logger.info("Dry run requested, skipping ingress request submission.")
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ install_requires =
     boto3
     boto3-stubs[apigateway,cognito,essential]
     requests>=2.23
+    types-requests
     PyYAML~=6.0
     types-PyYAML~=6.0
 

--- a/src/pds/ingress/util/auth_util.py
+++ b/src/pds/ingress/util/auth_util.py
@@ -7,11 +7,9 @@ Module containing functions for performing user authentication to the
 Ingress Service Lambda.
 
 """
-import logging
-
 import boto3  # type: ignore
 
-logger = logging.getLogger(__name__)
+from .log_util import get_logger
 
 
 class AuthUtil:
@@ -44,6 +42,8 @@ class AuthUtil:
             If authentication fails for any reason.
 
         """
+        logger = get_logger(__name__)
+
         client = boto3.client("cognito-idp", region_name=cognito_config["region"])
 
         auth_params = {"USERNAME": cognito_config["username"], "PASSWORD": cognito_config["password"]}
@@ -82,6 +82,8 @@ class AuthUtil:
             an HTTP request.
 
         """
+        logger = get_logger(__name__)
+
         logger.info("Creating Bearer token")
 
         access_token = authentication_result["AccessToken"]

--- a/src/pds/ingress/util/conf.default.ini
+++ b/src/pds/ingress/util/conf.default.ini
@@ -17,3 +17,5 @@ region       = us-west-2
 
 [OTHER]
 log_level = INFO
+log_format = "%(levelname)s %(name)s:%(funcName)s %(message)s"
+log_group_name = "PDSDataUploadManagerLogGroup"

--- a/src/pds/ingress/util/config_util.py
+++ b/src/pds/ingress/util/config_util.py
@@ -8,12 +8,11 @@ Ingress client script.
 
 """
 import configparser
-import logging
 import os
 
 from pkg_resources import resource_filename
 
-logger = logging.getLogger(__name__)
+CONFIG = None
 
 
 class ConfigUtil:
@@ -33,6 +32,14 @@ class ConfigUtil:
         Returns a ConfigParser instance containing the parsed contents of the
         requested config path.
 
+        Notes
+        -----
+        After the initial call to this method, the parsed config object is
+        cached as the singleton to be returned by all subsequent calls to
+        get_config(). This ensures that the initialized config can be obtained
+        by any subsequent callers without needing to know the path to the
+        originating INI file.
+
         Parameters
         ----------
         config_path : str, optional
@@ -45,6 +52,11 @@ class ConfigUtil:
             The parser instance containing the contents of the read config.
 
         """
+        global CONFIG
+
+        if CONFIG is not None:
+            return CONFIG
+
         if not config_path:
             config_path = ConfigUtil.default_config_path()
 
@@ -53,13 +65,11 @@ class ConfigUtil:
         if not os.path.exists(config_path):
             raise ValueError(f"Requested config {config_path} does not exist")
 
-        parser = configparser.ConfigParser()
-
-        logger.info(f"Loading config file {config_path}")
+        parser = configparser.RawConfigParser()
 
         with open(config_path, "r") as infile:
             parser.read_file(infile, source=os.path.basename(config_path))
 
-        # TODO: add validation to ensure provided INI conforms to expected format
+        CONFIG = parser
 
-        return parser
+        return CONFIG

--- a/src/pds/ingress/util/log_util.py
+++ b/src/pds/ingress/util/log_util.py
@@ -1,0 +1,315 @@
+"""
+===========
+log_util.py
+===========
+
+Module containing functions related to logging and set up of the logger used
+with the ingress client.
+
+"""
+import json
+import logging
+from datetime import datetime
+from logging.handlers import BufferingHandler
+
+import requests
+
+from .config_util import ConfigUtil
+from .node_util import NodeUtil
+
+MILLI_PER_SEC = 1000
+
+LOG_LEVELS = {"warn": logging.WARNING, "warning": logging.WARNING, "info": logging.INFO, "debug": logging.DEBUG}
+"""Constant to help evaluate what level to do logging at."""
+
+CONSOLE_HANDLER = None
+"""Handle to the StreamHandler singleton to be allocated to all logger objects"""
+
+CLOUDWATCH_HANDLER = None
+"""Handle to the CloudWatchHandler singleton to be allocated to all logger objects"""
+
+
+def get_log_level(log_level):
+    """Translates name of a log level to the constant used by the logging module"""
+    return LOG_LEVELS[log_level.lower()]
+
+
+def get_logger(name):
+    """
+    Returns the logging object for the provided module name.
+
+    Parameters
+    ----------
+    name : str
+        Name of the module to get a logger for.
+
+    Returns
+    -------
+    logger : logging.logger
+        The logger for the specified module name.
+
+    """
+    _logger = logging.getLogger(name)
+
+    return setup_logging(_logger, ConfigUtil.get_config())
+
+
+def setup_logging(logger, config):
+    """
+    Sets up a logger object with handler objects for logging to the console,
+    as well as the buffer that submits logs to CloudWatch.
+
+    Parameters
+    ----------
+    logger : logging.logger
+        The logger object to set up.
+    config : ConfigParser
+        The parsed config used to initialize the log handlers.
+
+    Returns
+    -------
+    logger : logging.logger
+        The setup logger object.
+
+    """
+    log_level = get_log_level(config["OTHER"]["log_level"])
+    logger.setLevel(log_level)
+
+    return setup_console_log(setup_cloudwatch_log(logger, config), config)
+
+
+def setup_console_log(logger, config):
+    """
+    Sets up the handler used to log to the console.
+
+    Parameters
+    ----------
+    logger : logging.logger
+        The logger object to set up.
+    config : ConfigParser
+        The parsed config used to initialize the console log handler.
+
+    Returns
+    -------
+    logger : logging.logger
+        The setup logger object.
+
+    """
+    global CONSOLE_HANDLER
+
+    log_format = logging.Formatter(config["OTHER"]["log_format"])
+    log_level = get_log_level(config["OTHER"]["log_level"])
+
+    if CONSOLE_HANDLER is None:
+        CONSOLE_HANDLER = logging.StreamHandler()
+        CONSOLE_HANDLER.setLevel(log_level)
+        CONSOLE_HANDLER.setFormatter(log_format)
+
+    if CONSOLE_HANDLER not in logger.handlers:
+        logger.addHandler(CONSOLE_HANDLER)
+
+    return logger
+
+
+def setup_cloudwatch_log(logger, config):
+    """
+    Sets up the handler used to log to AWS CloudWatch Logs.
+
+    Notes
+    -----
+    After the initial call to this function, the created handler object is
+    cached as the singleton to be returned by all subsequent calls to
+    setup_cloudwatch_log(). This ensures that loggers for all modules submit
+    their logged messages to the same buffer which is eventually submitted to
+    CloudWatch.
+
+    Parameters
+    ----------
+    logger : logging.logger
+        The logger object to set up.
+    config : ConfigParser
+        The parsed config used to initialize the console log handler.
+
+    Returns
+    -------
+    logger : logging.logger
+        The setup logger object.
+
+    """
+    global CLOUDWATCH_HANDLER
+
+    log_format = logging.Formatter(config["OTHER"]["log_format"])
+    log_level = get_log_level(config["OTHER"]["log_level"])
+    log_group_name = config["OTHER"]["log_group_name"]
+
+    if CLOUDWATCH_HANDLER is None:
+        CLOUDWATCH_HANDLER = CloudWatchHandler(log_group_name, config["API_GATEWAY"])
+
+        CLOUDWATCH_HANDLER.setLevel(log_level)
+        CLOUDWATCH_HANDLER.setFormatter(log_format)
+
+    if CLOUDWATCH_HANDLER not in logger.handlers:
+        logger.addHandler(CLOUDWATCH_HANDLER)
+
+    return logger
+
+
+class CloudWatchHandler(BufferingHandler):
+    """
+    Specialization of the BufferingHandler class that submits all buffered log
+    records to CloudWatch Logs via an API Gateway endpoint when flushed.
+
+    Notes
+    -----
+    In order for this handler to communicate with API Gateway, the bearer_token
+    and node_id properties must be set on an instance prior to the first
+    invocation of the flush() method.
+
+    """
+
+    def __init__(self, log_group_name, api_gateway_config, capacity=1024):
+        super().__init__(capacity)
+
+        self.log_group_name = log_group_name
+        self.api_gateway_config = api_gateway_config
+        self.creation_time = datetime.now().strftime("%s")
+        self._bearer_token = None
+        self._node_id = None
+
+    @property
+    def bearer_token(self):
+        """Returns the authentication bearer token set on this handler"""
+        return self._bearer_token
+
+    @bearer_token.setter
+    def bearer_token(self, token):
+        """Sets the authentication bearer token on this handler"""
+        self._bearer_token = token
+
+    @property
+    def node_id(self):
+        """Returns the PDS node ID set on this handler"""
+        return self._node_id
+
+    @node_id.setter
+    def node_id(self, _id):
+        """Sets the PDS node ID on this handler"""
+        self._node_id = _id
+
+    def emit(self, record):
+        """
+        Emit a record.
+
+        Append the record. If shouldFlush() tells us to, call flush() to process
+        the buffer.
+        """
+        self.buffer.append(record)
+
+        if self.shouldFlush(record):
+            self.flush()
+
+    def flush(self):
+        """
+        Flushes the buffered log messages by submitting all log records to
+        AWS CloudWatch Logs via an API Gateway endpoint. After a successful
+        invocation of this method, the buffer is cleared.
+        """
+        self.acquire()
+
+        try:
+            log_events = [
+                {
+                    "timestamp": int(round(record.created)) * MILLI_PER_SEC,
+                    "message": f"{record.levelname} {record.message}",
+                }
+                for record in self.buffer
+            ]
+
+            # CloudWatch Logs wants all records sorted by ascending timestamp
+            log_events = list(sorted(log_events, key=lambda event: event["timestamp"]))
+
+            self.send_log_events_to_cloud_watch(log_events)
+
+            self.buffer.clear()
+        except Exception as err:
+            # Use the root logger since the console logger singleton may have been
+            # closed by the time flush() is called
+            logging.warning(f"Unable to submit to CloudWatch Logs, reason: {str(err)}")
+        finally:
+            self.release()
+
+    def send_log_events_to_cloud_watch(self, log_events):
+        """
+        Bundles the provided log events into a JSON payload and submits it
+        to the API Gateway endpoint configured for CloudWatch Logs.
+
+        Parameters
+        ----------
+        log_events : list
+            List of log events converted to dictionaries suitable for submission
+            to CloudWatch Logs.
+
+        Raises
+        ------
+        ValueError
+            If no Bearer Token was set on this handler to use with authentication
+            to the API Gateway endpoint.
+
+        RuntimeError
+            If the submission to API Gateway fails for any reason.
+
+        """
+        if self.bearer_token is None or self.node_id is None:
+            raise ValueError(
+                "Bearer token and/or Node ID was never set on CloudWatchHandler, "
+                "unable to communicate with API Gateway endpoint for CloudWatch Logs."
+            )
+
+        # Extract the API Gateway configuration params
+        api_gateway_template = self.api_gateway_config["url_template"]
+        api_gateway_id = self.api_gateway_config["id"]
+        api_gateway_region = self.api_gateway_config["region"]
+        api_gateway_stage = self.api_gateway_config["stage"]
+
+        # Create the log stream for the current run.
+        # If the stream already exists, attempting to recreate should not raise an error.
+        log_stream_name = f"pds-ingress-client-{self.node_id}-{self.creation_time}"
+        api_gateway_resource = "createstream"
+
+        api_gateway_url = api_gateway_template.format(
+            id=api_gateway_id, region=api_gateway_region, stage=api_gateway_stage, resource=api_gateway_resource
+        )
+        payload = {"logGroupName": self.log_group_name, "logStreamName": log_stream_name}
+        headers = {
+            "Authorization": self.bearer_token,
+            "UserGroup": NodeUtil.node_id_to_group_name(self.node_id),
+            "content-type": "application/json",
+            "x-amz-docs-region": api_gateway_region,
+        }
+
+        try:
+            response = requests.post(api_gateway_url, data=json.dumps(payload), headers=headers)
+            response.raise_for_status()
+        except requests.exceptions.HTTPError as err:
+            raise RuntimeError(f"Failed to create CloudWatch Log Stream {log_stream_name}, reason: {str(err)}") from err
+
+        # Now submit logged content to the newly created log stream
+        api_gateway_resource = "log"
+        api_gateway_url = api_gateway_template.format(
+            id=api_gateway_id, region=api_gateway_region, stage=api_gateway_stage, resource=api_gateway_resource
+        )
+
+        # Add the log events to the existing payload containing the log group/stream names
+        payload["logEvents"] = log_events
+        headers = {
+            "Authorization": self.bearer_token,
+            "UserGroup": NodeUtil.node_id_to_group_name(self.node_id),
+            "content-type": "application/json",
+            "x-amz-docs-region": api_gateway_region,
+        }
+
+        try:
+            response = requests.post(api_gateway_url, data=json.dumps(payload), headers=headers)
+            response.raise_for_status()
+        except requests.exceptions.HTTPError as err:
+            raise RuntimeError(f"Submission to CloudWatch Logs failed, reason: {str(err)}") from err

--- a/src/pds/ingress/util/node_util.py
+++ b/src/pds/ingress/util/node_util.py
@@ -6,9 +6,6 @@ node_util.py
 Module containing functions for working with PDS Node identifiers.
 
 """
-import logging
-
-logger = logging.getLogger(__name__)
 
 
 class NodeUtil:

--- a/src/pds/ingress/util/path_util.py
+++ b/src/pds/ingress/util/path_util.py
@@ -6,10 +6,9 @@ path_util.py
 Module containing functions for working with local file system paths.
 
 """
-import logging
 import os
 
-logger = logging.getLogger(__name__)
+from .log_util import get_logger
 
 
 class PathUtil:
@@ -37,6 +36,8 @@ class PathUtil:
             paths.
 
         """
+        logger = get_logger(__name__)
+
         # Initialize the list of resolved paths if necessary
         resolved_paths = resolved_paths or list()
 
@@ -91,6 +92,8 @@ class PathUtil:
             is provided, the untrimmed path is returned.
 
         """
+        logger = get_logger(__name__)
+
         trimmed_ingress_path = ingress_path
 
         # Remove path prefix if one was configured

--- a/tests/pds/ingress/util/test_log_util.py
+++ b/tests/pds/ingress/util/test_log_util.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+import json as json_module
+import logging
+import unittest
+from unittest.mock import patch
+
+import pds.ingress.util.log_util as log_util
+import requests
+from pds.ingress.util.config_util import ConfigUtil
+from pds.ingress.util.node_util import NodeUtil
+
+
+class LogUtilTest(unittest.TestCase):
+    def test_setup_logging(self):
+        """Tests for log_util.setup_logging()"""
+        logger = logging.getLogger(__name__)
+        config = ConfigUtil.get_config()
+
+        logger = log_util.setup_logging(logger, config)
+
+        self.assertEqual(logger.level, log_util.get_log_level(config["OTHER"]["log_level"]))
+        self.assertEqual(len(logger.handlers), 2)
+
+        self.assertIn(log_util.CONSOLE_HANDLER, logger.handlers)
+        self.assertEqual(log_util.CONSOLE_HANDLER.level, log_util.get_log_level(config["OTHER"]["log_level"]))
+        self.assertIsNotNone(log_util.CONSOLE_HANDLER.formatter)
+        self.assertEqual(log_util.CONSOLE_HANDLER.formatter._fmt, config["OTHER"]["log_format"])
+
+        self.assertIn(log_util.CLOUDWATCH_HANDLER, logger.handlers)
+        self.assertEqual(log_util.CLOUDWATCH_HANDLER.level, log_util.get_log_level(config["OTHER"]["log_level"]))
+        self.assertIsNotNone(log_util.CLOUDWATCH_HANDLER.formatter)
+        self.assertEqual(log_util.CLOUDWATCH_HANDLER.formatter._fmt, config["OTHER"]["log_format"])
+        self.assertEqual(log_util.CLOUDWATCH_HANDLER.log_group_name, config["OTHER"]["log_group_name"])
+
+        self.assertIsNone(log_util.CLOUDWATCH_HANDLER.bearer_token)
+        self.assertIsNone(log_util.CLOUDWATCH_HANDLER.node_id)
+
+    def test_send_log_events_to_cloud_watch(self):
+        """Tests for CloudWatchHandler.send_log_events_to_cloud_watch()"""
+        logger = logging.getLogger(__name__)
+        config = ConfigUtil.get_config()
+
+        logger = log_util.setup_logging(logger, config)
+
+        logger.handlers.remove(log_util.CONSOLE_HANDLER)
+
+        logger.info("Test message")
+
+        # Ensure we see the following message logged when attempting to flush
+        # to CloudWatch before the Cognito authentication information is set
+        with self.assertLogs(level="WARNING") as cm:
+            log_util.CLOUDWATCH_HANDLER.flush()
+            self.assertIn(
+                "WARNING:root:Unable to submit to CloudWatch Logs, reason: "
+                "Bearer token and/or Node ID was never set on CloudWatchHandler, "
+                "unable to communicate with API Gateway endpoint for CloudWatch Logs.",
+                cm.output,
+            )
+
+        # Set dummy Cognito authentication values on handler
+        log_util.CLOUDWATCH_HANDLER.bearer_token = "Bearer faketoken"
+        log_util.CLOUDWATCH_HANDLER.node_id = "eng"
+
+        def requests_post_patch(url, data=None, json=None, **kwargs):
+            """Mock implementation for requests.post()"""
+            # Test that the API gateway URL was formatted as expected
+            self.assertIn(config["API_GATEWAY"]["id"], url)
+            self.assertIn(config["API_GATEWAY"]["region"], url)
+            self.assertIn(config["API_GATEWAY"]["stage"], url)
+
+            # Check contents of the request payload
+            payload = json_module.loads(data)
+            self.assertIn("logGroupName", payload)
+            self.assertIn("logStreamName", payload)
+            self.assertEqual(payload["logGroupName"], log_util.CLOUDWATCH_HANDLER.log_group_name)
+
+            # Ensure node ID assigned to the handler was assigned to the log stream name
+            log_stream_name = payload["logStreamName"]
+            self.assertIn("eng", log_stream_name)
+
+            # If log events were included, ensure test log message was captured
+            if "logEvents" in payload:
+                self.assertEqual(len(payload["logEvents"]), 1)
+                self.assertEqual(payload["logEvents"][0]["message"], "INFO Test message")
+
+            # Ensure the authentication headers were set as expected
+            headers = kwargs["headers"]
+            self.assertIn("Authorization", headers)
+            self.assertIn("UserGroup", headers)
+            self.assertEqual(headers["Authorization"], "Bearer faketoken")
+            self.assertEqual(headers["UserGroup"], NodeUtil.node_id_to_group_name("eng"))
+
+            response = requests.Response()
+            response.status_code = 200
+
+            return response
+
+        try:
+            with patch.object(log_util.requests, "post", requests_post_patch):
+                log_util.CLOUDWATCH_HANDLER.flush()
+        finally:
+            log_util.CLOUDWATCH_HANDLER.bearer_token = None
+            log_util.CLOUDWATCH_HANDLER.node_id = None

--- a/tests/pds/ingress/util/test_log_util.py
+++ b/tests/pds/ingress/util/test_log_util.py
@@ -35,6 +35,20 @@ class LogUtilTest(unittest.TestCase):
         self.assertIsNone(log_util.CLOUDWATCH_HANDLER.bearer_token)
         self.assertIsNone(log_util.CLOUDWATCH_HANDLER.node_id)
 
+        # Test with log level override
+        logger = logging.getLogger("test")
+        log_util.CONSOLE_HANDLER = None
+        log_util.CLOUDWATCH_HANDLER = None
+
+        logger = log_util.setup_logging(logger, config, log_util.get_log_level("warning"))
+
+        self.assertEqual(len(logger.handlers), 2)
+        self.assertIsNotNone(log_util.CONSOLE_HANDLER)
+        self.assertIsNotNone(log_util.CLOUDWATCH_HANDLER)
+        self.assertEqual(logger.level, log_util.get_log_level("warning"))
+        self.assertEqual(log_util.CONSOLE_HANDLER.level, log_util.get_log_level("warning"))
+        self.assertEqual(log_util.CLOUDWATCH_HANDLER.level, log_util.get_log_level("warning"))
+
     def test_send_log_events_to_cloud_watch(self):
         """Tests for CloudWatchHandler.send_log_events_to_cloud_watch()"""
         logger = logging.getLogger(__name__)


### PR DESCRIPTION
## 🗒️ Summary
This branch adds a logging utility module to the DUM codebase which supports submission of all logged messages to AWS CloudWatch Logs via an API Gateway endpoint. Submission to the endpoint leverages the same Cognito authentication credentials as the endpoint used to request S3 ingress.

## ⚙️ Test Data and/or Report
A unit test module has been added for the new `log_utils.py` module.

## ♻️ Related Issues
Resolves #21 


