### PR TITLE
Parallel upload support

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ classifiers =
 install_requires =
     boto3
     boto3-stubs[apigateway,cognito,essential]
+    joblib
     requests>=2.23
     types-requests
     PyYAML~=6.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,11 +28,11 @@ classifiers =
 
 [options]
 install_requires =
-    boto3
-    boto3-stubs[apigateway,cognito,essential]
-    joblib
+    boto3~=1.25
+    boto3-stubs[apigateway,cognito,essential]~=1.25
+    joblib~=1.3.1
     requests>=2.23
-    types-requests
+    types-requests>=2.23
     PyYAML~=6.0
     types-PyYAML~=6.0
 

--- a/src/pds/ingress/util/conf.default.ini
+++ b/src/pds/ingress/util/conf.default.ini
@@ -17,5 +17,5 @@ region       = us-west-2
 
 [OTHER]
 log_level = INFO
-log_format = "%(levelname)s %(name)s:%(funcName)s %(message)s"
+log_format = "%(levelname)s %(threadName)s %(name)s:%(funcName)s %(message)s"
 log_group_name = "PDSDataUploadManagerLogGroup"

--- a/src/pds/ingress/util/log_util.py
+++ b/src/pds/ingress/util/log_util.py
@@ -229,7 +229,7 @@ class CloudWatchHandler(BufferingHandler):
             log_events = [
                 {
                     "timestamp": int(round(record.created)) * MILLI_PER_SEC,
-                    "message": f"{record.levelname} {record.message}",
+                    "message": f"{record.levelname} {record.threadName} {record.name}:{record.funcName} {record.message}",
                 }
                 for record in self.buffer
             ]


### PR DESCRIPTION
## 🗒️ Summary
This branch incorporates the use of the `joblib` library to parallelize the ingress requests and transfers to S3 on the list of requested files. The number of concurrent "threads" to utilizes can be controlled with a new `--num-threads` command line option.

## ⚙️ Test Data and/or Report
No unit tests have been affected or updated by this branch. 
Parallel uploads have been tested in NGAP using a 4 core machine. Running with different settings for `--num-threads` produces the expected improvement in runtime (i.e. single thread -> 1 minute, 2 threads -> 30 s, 4 threads -> 15 s).

## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->
Resolves #24 

