### PR TITLE
Log Handler Fixes

### DIFF
--- a/scripts/pds-ingress-client.py
+++ b/scripts/pds-ingress-client.py
@@ -210,9 +210,9 @@ def setup_argparser():
                              'performing any submission requests to the server.')
     parser.add_argument('--log-level', '-l', type=str, default=None,
                         choices=["warn", "warning", "info", "debug"],
-                        help="Sets the Logging level for logged messages. If not "
-                             "provided, the logging level set in the INI config "
-                             "is used instead.")
+                        help="Sets the Logging level for messages logged to the "
+                             "console. If not provided, the logging level set in "
+                             "the INI config is used instead.")
     parser.add_argument('ingress_paths', type=str, nargs='+',
                         metavar='file_or_dir',
                         help='One or more paths to the files to ingest to S3. '

--- a/src/pds/ingress/util/log_util.py
+++ b/src/pds/ingress/util/log_util.py
@@ -212,6 +212,7 @@ class CloudWatchHandler(BufferingHandler):
         Append the record. If shouldFlush() tells us to, call flush() to process
         the buffer.
         """
+        self.format(record)
         self.buffer.append(record)
 
         if self.shouldFlush(record):

--- a/tests/pds/ingress/util/test_log_util.py
+++ b/tests/pds/ingress/util/test_log_util.py
@@ -13,12 +13,12 @@ from pds.ingress.util.node_util import NodeUtil
 class LogUtilTest(unittest.TestCase):
     def test_setup_logging(self):
         """Tests for log_util.setup_logging()"""
-        logger = logging.getLogger(__name__)
+        logger = log_util.get_logger("test1")
         config = ConfigUtil.get_config()
 
         logger = log_util.setup_logging(logger, config)
 
-        self.assertEqual(logger.level, log_util.get_log_level(config["OTHER"]["log_level"]))
+        self.assertEqual(logger.level, log_util.get_log_level("debug"))
         self.assertEqual(len(logger.handlers), 2)
 
         self.assertIn(log_util.CONSOLE_HANDLER, logger.handlers)
@@ -36,18 +36,19 @@ class LogUtilTest(unittest.TestCase):
         self.assertIsNone(log_util.CLOUDWATCH_HANDLER.node_id)
 
         # Test with log level override
-        logger = logging.getLogger("test")
         log_util.CONSOLE_HANDLER = None
         log_util.CLOUDWATCH_HANDLER = None
-
-        logger = log_util.setup_logging(logger, config, log_util.get_log_level("warning"))
+        logger = log_util.get_logger("test2", log_util.get_log_level("warning"))
 
         self.assertEqual(len(logger.handlers), 2)
         self.assertIsNotNone(log_util.CONSOLE_HANDLER)
         self.assertIsNotNone(log_util.CLOUDWATCH_HANDLER)
-        self.assertEqual(logger.level, log_util.get_log_level("warning"))
+        self.assertEqual(logger.level, log_util.get_log_level("debug"))
         self.assertEqual(log_util.CONSOLE_HANDLER.level, log_util.get_log_level("warning"))
-        self.assertEqual(log_util.CLOUDWATCH_HANDLER.level, log_util.get_log_level("warning"))
+
+        # Provided log level should only affect console, CloudWatch logger
+        # always defaults to what is defined in the INI
+        self.assertEqual(log_util.CLOUDWATCH_HANDLER.level, log_util.get_log_level(config["OTHER"]["log_level"]))
 
     def test_send_log_events_to_cloud_watch(self):
         """Tests for CloudWatchHandler.send_log_events_to_cloud_watch()"""


### PR DESCRIPTION
<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->

## 🗒️ Summary
This branch fixes several issues related to logging by the ingress client which were discovered during integration testing with Nucleus.

Fixes include:
- Fix to `CloudWatchHandler` class to ensure received `LogRecord` objects are formatted before the logged content is pushed to CloudWatch.
- Fix to handling of logging levels during logger setup to ensure that each assigned handler can have its own distinct logging level assigned (and respected by the parent `Logger` object)
- The `--log-level` argument now only affects logging to the console. The log level utilized by the `CloudWatchHandler` object is now always taken from the INI config.

## ⚙️ Test Data and/or Report
Unit tests for the logging module have been updated to account for fixes made.

## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->
Resolves #43 

