### PR TITLE
deactivate central logs, interim solution for ticket #75

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Our unit tests are launched with command:
 
 You can build this projects' docs with:
 
-    python setup.py build_sphinx
+    sphinx-build docs/source docs/build
 
 You can access the build files in the following directory relative to the project root:
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,8 +66,8 @@ dev =
     pytest-watch~=4.2.0
     pytest-xdist~=3.3.1
     pre-commit~=3.3.3
-    sphinx~=3.2.1
-    sphinx-rtd-theme~=0.5.0
+    sphinx~=7.2.6
+    sphinx-rtd-theme~=2.0.0
     tox~=4.11.0
     types-setuptools~=68.1.0.0
     Jinja2<3.1

--- a/src/pds/ingress/util/log_util.py
+++ b/src/pds/ingress/util/log_util.py
@@ -246,7 +246,8 @@ class CloudWatchHandler(BufferingHandler):
             # CloudWatch Logs wants all records sorted by ascending timestamp
             log_events = list(sorted(log_events, key=lambda event: event["timestamp"]))
 
-            self.send_log_events_to_cloud_watch(log_events)
+            # deactivated until https://github.com/NASA-PDS/data-upload-manager/issues/75 is fixed
+            # self.send_log_events_to_cloud_watch(log_events)
 
             self.buffer.clear()
         except Exception as err:

--- a/tests/pds/ingress/util/test_log_util.py
+++ b/tests/pds/ingress/util/test_log_util.py
@@ -50,6 +50,7 @@ class LogUtilTest(unittest.TestCase):
         # always defaults to what is defined in the INI
         self.assertEqual(log_util.CLOUDWATCH_HANDLER.level, log_util.get_log_level(config["OTHER"]["log_level"]))
 
+    @unittest.skip("skip because of bug https://github.com/NASA-PDS/data-upload-manager/issues/75")
     def test_send_log_events_to_cloud_watch(self):
         """Tests for CloudWatchHandler.send_log_events_to_cloud_watch()"""
         logger = logging.getLogger(__name__)

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ commands = pytest
 [testenv:docs]
 deps = .[dev]
 whitelist_externals = python
-commands = python setup.py build_sphinx
+commands = sphinx-build docs/source docs/build
 
 [testenv:lint]
 deps = pre-commit


### PR DESCRIPTION
<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->


## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->

fixes https://github.com/NASA-PDS/data-upload-manager/issues/78

 


