### PR TITLE
Renable Logging to CloudWatch

### DIFF
--- a/docs/source/terraform/index.rst
+++ b/docs/source/terraform/index.rst
@@ -74,7 +74,7 @@ prior to deployment. Descriptions of each field follow:
 * The `nucleus_dum_cognito_initial_users` can be populated with a list of dictionaries defining a set of user accounts to
   populate the Cognito user pool with upon creation. An arbitrary number of initial users can be provided.
   * The ``<Username>`` and ``<Password>`` fields can be anything, but the password must conform to the Password policy set on the Cognito user pool.
-  * For ``<PDS_Group_Name>``, one of the following may be used: ``PDS_ATM_USERS, PDS_ENG_USERS, PDS_GEO_NODE, PDS_IMG_NODE, PDS_NAIF_NODE, PDS_PPI_NODE, PDS_RS_NODE, PDS_RMS_NODE, PDS_SBN_NODE``
+  * For ``<PDS_Group_Name>``, one of the following may be used: ``PDS_ATM_USERS, PDS_ENG_USERS, PDS_GEO_USERS, PDS_IMG_NODE, PDS_NAIF_USERS, PDS_PPI_USERS, PDS_RS_USERS, PDS_RMS_USERS, PDS_SBN_USERS``
   * ``<Email address>`` should be a valid email address for the user, as this is where things such as password resets will be sent.
 
 Deploying the Terraform

--- a/docs/source/terraform/index.rst
+++ b/docs/source/terraform/index.rst
@@ -44,6 +44,8 @@ template can be used when creating a new `tfvars` file for use with a specific A
 
     api_gateway_policy_source_vpc = "<VPC_ID>"
 
+    api_gateway_endpoint_type = <"REGIONAL"|"PRIVATE">
+
     api_gateway_lambda_role_arn         = "<AWS_IAM_Role_ARN>"
     lambda_ingress_service_iam_role_arn = "<AWS_IAM_Role_ARN>"
     lambda_authorizer_iam_role_arn      = "<AWS_IAM_Role_ARN>"
@@ -66,6 +68,7 @@ prior to deployment. Descriptions of each field follow:
 * ``<S3_Bucket_Name>``: Name of an S3 bucket which Terraform will use to stage intermediate build products. The bucket will be created by Terraform and should not already exist.
 * ``<VPC_ID>``: ID of the Virtual Private Cloud instance where the deployed service will reside.
 * ``<AWS_IAM_Role_ARN>``: Amazon Resource Name (ARN) for the AWS Identity Access Management Role which grants the required permissions for the DUM server components to communicate.
+* ``<"REGIONAL"|"PRIVATE">``: Select the type of endpoint of the API Gateway. "REGIONAL" should only be used for deployments to the OPS environment.
 
 .. note::
   * The selected Role(s) must include both ``lambda.amazonaws.com`` and ``apigateway.amazonaws.com`` as "Trusted Entities".

--- a/src/pds/ingress/util/log_util.py
+++ b/src/pds/ingress/util/log_util.py
@@ -246,8 +246,7 @@ class CloudWatchHandler(BufferingHandler):
             # CloudWatch Logs wants all records sorted by ascending timestamp
             log_events = list(sorted(log_events, key=lambda event: event["timestamp"]))
 
-            # deactivated until https://github.com/NASA-PDS/data-upload-manager/issues/75 is fixed
-            # self.send_log_events_to_cloud_watch(log_events)
+            self.send_log_events_to_cloud_watch(log_events)
 
             self.buffer.clear()
         except Exception as err:

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -34,6 +34,7 @@ module "nucleus_dum_api" {
   source = "./modules/api_gateway"
 
   cloudwatch_iam_role_name             = var.cloudwatch_iam_role_name
+  api_gateway_endpoint_type            = var.api_gateway_endpoint_type
   api_gateway_lambda_role_arn          = var.api_gateway_lambda_role_arn
   api_gateway_policy_source_vpc        = var.api_gateway_policy_source_vpc
   lambda_authorizer_function_arn       = module.nucleus_dum_lambda_authorizer.lambda_authorizer_function_arn

--- a/terraform/modules/api_gateway/api_gateway.tf
+++ b/terraform/modules/api_gateway/api_gateway.tf
@@ -9,7 +9,7 @@ resource "aws_api_gateway_rest_api" "nucleus_dum_api" {
   description = var.rest_api_description
 
   endpoint_configuration {
-    types = ["REGIONAL"]
+    types = [var.api_gateway_endpoint_type]
   }
 
   body = templatefile(

--- a/terraform/modules/api_gateway/api_gateway.tf
+++ b/terraform/modules/api_gateway/api_gateway.tf
@@ -9,7 +9,7 @@ resource "aws_api_gateway_rest_api" "nucleus_dum_api" {
   description = var.rest_api_description
 
   endpoint_configuration {
-    types = ["PRIVATE"]  # TODO this will change to "REGIONAL" at some point (?)
+    types = ["REGIONAL"]
   }
 
   body = templatefile(

--- a/terraform/modules/api_gateway/templates/data-upload-manager-oas30-apigateway.yaml.tftpl
+++ b/terraform/modules/api_gateway/templates/data-upload-manager-oas30-apigateway.yaml.tftpl
@@ -119,16 +119,5 @@ components:
       x-amazon-apigateway-authorizer:
         authorizerUri: "arn:aws:apigateway:${awsRegion}:lambda:path/2015-03-31/functions/${lambdaAuthorizerARN}/invocations"
         authorizerCredentials: ${apiGatewayLambdaRole}
-        authorizerResultTtlInSeconds: 300
         identitySource: "method.request.header.Authorization, method.request.header.UserGroup"
         type: "request"
-x-amazon-apigateway-policy:
-  Version: "2012-10-17"
-  Statement:
-  - Effect: "Allow"
-    Principal: "*"
-    Action: "*"
-    Resource: "*"
-    Condition:
-      StringEquals:
-        aws:SourceVpc: "${apiGatewaySourceVpc}"

--- a/terraform/modules/api_gateway/variables.tf
+++ b/terraform/modules/api_gateway/variables.tf
@@ -17,6 +17,12 @@ variable "rest_api_description" {
   description = "Description text for the DUM API Gateway"
 }
 
+variable "api_gateway_endpoint_type" {
+  type        = string
+  default     = "PRIVATE"
+  description = "The endpoint type to assign to the API Gateway. Should be one of PRIVATE or REGIONAL"
+}
+
 variable "api_gateway_lambda_role_arn" {
   type        = string
   description = "ARN of the IAM role to assign to the API Gateway. Must have permission to access AWS Lambda."

--- a/terraform/modules/cognito/variables.tf
+++ b/terraform/modules/cognito/variables.tf
@@ -61,31 +61,31 @@ variable "nucleus_dum_cognito_user_groups" {
       description = "User group for PDS Engineering Node"
     },
     {
-      name        = "PDS_GEO_NODE"
+      name        = "PDS_GEO_USERS"
       description = "User group for PDS Geosciences Node"
     },
     {
-      name        = "PDS_IMG_NODE"
+      name        = "PDS_IMG_USERS"
       description = "User group for PDS Cartography and Imaging Sciences Discipline Node"
     },
     {
-      name        = "PDS_NAIF_NODE"
+      name        = "PDS_NAIF_USERS"
       description = "User group for PDS Navigational and Ancillary Information Facility Node"
     },
     {
-      name        = "PDS_PPI_NODE"
+      name        = "PDS_PPI_USERS"
       description = "User group for PDS Planetary Plasma Interactions Node"
     },
     {
-      name        = "PDS_RS_NODE"
+      name        = "PDS_RS_USERS"
       description = "User group for PDS Radio Science Node"
     },
     {
-      name        = "PDS_RMS_NODE",
+      name        = "PDS_RMS_USERS",
       description = "User group for PDS Ring-Moon Systems Node"
     },
     {
-      name        = "PDS_SBN_NODE",
+      name        = "PDS_SBN_USERS",
       description = "User group for PDS Small Bodies Node"
     }
   ]

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -25,6 +25,12 @@ variable "cloudwatch_iam_role_name" {
   description = "IAM Role name used for CloudWatch Logging"
 }
 
+variable "api_gateway_endpoint_type" {
+  type        = string
+  default     = "PRIVATE"
+  description = "The endpoint type to assign to the API Gateway. Should be one of PRIVATE or REGIONAL"
+}
+
 variable "api_gateway_lambda_role_arn" {
   type        = string
   description = "ARN for an IAM role which has permissions for both API Gateway and Lambda"

--- a/tests/pds/ingress/util/test_log_util.py
+++ b/tests/pds/ingress/util/test_log_util.py
@@ -50,7 +50,6 @@ class LogUtilTest(unittest.TestCase):
         # always defaults to what is defined in the INI
         self.assertEqual(log_util.CLOUDWATCH_HANDLER.level, log_util.get_log_level(config["OTHER"]["log_level"]))
 
-    @unittest.skip("skip because of bug https://github.com/NASA-PDS/data-upload-manager/issues/75")
     def test_send_log_events_to_cloud_watch(self):
         """Tests for CloudWatchHandler.send_log_events_to_cloud_watch()"""
         logger = logging.getLogger(__name__)


### PR DESCRIPTION
<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->

## 🗒️ Summary
This branch re-enables the function that pushes log messages to CloudWatch after successful execution of DUM. The functionality had been disabled since requests to push to CloudWatch always resulted in 403 Forbidden errors returned from API Gateway.

The underlying cause of this issue was traced to a credential caching feature enabled by default on API Gateway. After disabling caching, submission of logs to CloudWatch works again as expected.

This branch also includes some miscellaneous fixes to the Terraform scripts based on issues discovered during deployment to MCP Prod.

## ⚙️ Test Data and/or Report
* The disabled unit test for CloudWatch logging has also been renabled in this branch
* Existing unit tests all pass, no new tests added 

## ♻️ Related Issues
Resolves #75 
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->


