### PR TITLE
Skip ingress based on object metadata

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -85,6 +85,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -165,7 +169,7 @@
         "filename": "tests/pds/ingress/service/test_pds_ingress_app.py",
         "hashed_secret": "727d8ff68b6b550f2cf6e737b3cad5149c65fe5b",
         "is_verified": false,
-        "line_number": 76
+        "line_number": 82
       }
     ],
     "tests/pds/ingress/util/test_auth_util.py": [
@@ -185,5 +189,5 @@
       }
     ]
   },
-  "generated_at": "2023-11-16T16:50:51Z"
+  "generated_at": "2024-04-18T20:17:41Z"
 }

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ classifiers =
 
 [options]
 install_requires =
+    backoff~=2.2.1
     boto3~=1.25
     boto3-stubs[apigateway,cognito,essential]~=1.25
     joblib~=1.3.1

--- a/src/pds/ingress/service/pds_ingress_app.py
+++ b/src/pds/ingress/service/pds_ingress_app.py
@@ -166,7 +166,7 @@ def lambda_handler(event, context):
             f"No bucket location configured for prefix {prefix_key}, using default bucket {destination_bucket}"
         )
 
-    object_key = join(request_node.upper(), local_url)
+    object_key = join(request_node.lower(), local_url)
 
     s3_url = generate_presigned_upload_url(destination_bucket, object_key)
 

--- a/src/pds/ingress/service/pds_ingress_app.py
+++ b/src/pds/ingress/service/pds_ingress_app.py
@@ -9,9 +9,12 @@ to their destinations in S3.
 import json
 import logging
 import os
+from datetime import datetime
+from datetime import timezone
 from os.path import join
 
 import boto3
+import botocore
 import yaml
 from botocore.exceptions import ClientError
 
@@ -77,6 +80,63 @@ def initialize_bucket_map():
     return bucket_map
 
 
+def should_overwrite_file(destination_bucket, object_key, headers):
+    """
+    Determines if the file requested for ingress already exists in the S3
+    location we plan to upload to, and whether it should be overwritten with a
+    new version based on file info provided in the request headers.
+
+    Parameters
+    ----------
+    destination_bucket : str
+        Name of the S3 bucket to be uploaded to.
+    object_key : str
+        Object key location within the S3 bucket to be uploaded to.
+    headers : dict
+        Contains the headers of the ingress HTTP request from the client.
+        This includes information about the file that will be used to
+        determine if an overwrite on S3 should occur
+
+    Returns
+    -------
+    True if overwrite (or write) should occur, False otherwise.
+
+    """
+    s3_client = boto3.client("s3")
+
+    try:
+        object_head = s3_client.head_object(Bucket=destination_bucket, Key=object_key)
+    except botocore.exceptions.ClientError as e:
+        if e.response["Error"]["Code"] == "404":
+            # File does not already exist, safe to write
+            return True
+        else:
+            # Some other kind of unexpected error
+            raise
+
+    object_length = int(object_head["ContentLength"])
+    object_last_modified = object_head["LastModified"]
+    object_md5 = object_head["ETag"][1:-1]  # strip embedded quotes
+
+    logger.debug(f"{object_length=}")
+    logger.debug(f"{object_last_modified=}")
+    logger.debug(f"{object_md5=}")
+
+    request_length = int(headers["ContentLength"])
+    request_last_modified = datetime.fromtimestamp(float(headers["LastModified"]), tz=timezone.utc)
+    request_md5 = headers["ContentMD5"]
+
+    logger.debug(f"{request_length=}")
+    logger.debug(f"{request_last_modified=}")
+    logger.debug(f"{request_md5=}")
+
+    # If the request object differs from current version in S3 (newer, different contents),
+    # then it should be overwritten
+    return not (
+        object_length == request_length and object_md5 == request_md5 and object_last_modified >= request_last_modified
+    )
+
+
 def generate_presigned_upload_url(bucket_name, object_key, expires_in=1000):
     """
     Generates a presigned URL suitable for uploading to the S3 location
@@ -140,6 +200,7 @@ def lambda_handler(event, context):
 
     # Parse request details from event object
     body = json.loads(event["body"])
+    headers = event["headers"]
     local_url = body.get("url")
     request_node = event["queryStringParameters"].get("node")
 
@@ -168,6 +229,10 @@ def lambda_handler(event, context):
 
     object_key = join(request_node.lower(), local_url)
 
-    s3_url = generate_presigned_upload_url(destination_bucket, object_key)
+    if should_overwrite_file(destination_bucket, object_key, headers):
+        s3_url = generate_presigned_upload_url(destination_bucket, object_key)
 
-    return {"statusCode": 200, "body": json.dumps(s3_url)}
+        return {"statusCode": 200, "body": json.dumps(s3_url)}
+    else:
+        logger.info(f"{object_key} already exists in bucket {destination_bucket} and should not be overwritten")
+        return {"statusCode": 204}

--- a/tests/pds/ingress/service/test_pds_ingress_app.py
+++ b/tests/pds/ingress/service/test_pds_ingress_app.py
@@ -98,7 +98,7 @@ class PDSIngressAppTest(unittest.TestCase):
         response_body = json.loads(response["body"])
         response_url, signature_params = response_body.split("?")
 
-        expected_url = "https://nucleus-pds-protected.s3.amazonaws.com/SBN/gbo.ast.catalina.survey/bundle_gbo.ast.catalina.survey_v1.0.xml"
+        expected_url = "https://nucleus-pds-protected.s3.amazonaws.com/sbn/gbo.ast.catalina.survey/bundle_gbo.ast.catalina.survey_v1.0.xml"
 
         self.assertEqual(response_url, expected_url)
 
@@ -119,7 +119,7 @@ class PDSIngressAppTest(unittest.TestCase):
         response_url, signature_params = response_body.split("?")
 
         expected_url = (
-            "https://nucleus-pds-public.s3.amazonaws.com/SBN/some.other.survey/bundle.some.other.survey_v1.0.xml"
+            "https://nucleus-pds-public.s3.amazonaws.com/sbn/some.other.survey/bundle.some.other.survey_v1.0.xml"
         )
 
         self.assertEqual(response_url, expected_url)


### PR DESCRIPTION
<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->

## 🗒️ Summary
This branch adds the capability for the Data Upload Manager service to skip ingress of files that have been previously ingested and which have not changed since the last upload. The client application now includes several additional object metadata fields of the requested file (size, date modified, and md5) that allow the Lambda service function to determine if an existing file should be overwritten or skipped. This decision is communicated back to the client script, which takes the appropriate action.

## ⚙️ Test Data and/or Report
One of the following should be included here:
* Unit tests for Lambda service have been updated to test the function which makes the file overwrite determination
* Updates were deployed to MCP dev environment to test interactions between client and service

## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->
Resolves #92 
Fixes #90 
Resolves #87 
Resolves #51
Resolves #50 
Resolves #33 

