### PR TITLE
INI Config Quote Sanitization

### DIFF
--- a/docs/source/installation/index.rst
+++ b/docs/source/installation/index.rst
@@ -51,11 +51,11 @@ To do so::
 
     mkdir -p $HOME/.venv
     python3 -m venv $HOME/.venv/pds-data-upload-manager
-    source $HOME/.venv/pds-data-upload-manager/activate
+    source $HOME/.venv/pds-data-upload-manager/bin/activate
     pip3 install pds-data-upload-manager
 
 At this point, the PDS DUM client script is available under
-``$HOME/.venv/pds-doi-service/bin/pds-ingress-client``.
+``$HOME/.venv/pds-data-upload-manager/bin/pds-ingress-client``.
 
 Client Configuration
 ^^^^^^^^^^^^^^^^^^^^

--- a/src/pds/ingress/util/conf.default.ini
+++ b/src/pds/ingress/util/conf.default.ini
@@ -17,5 +17,5 @@ region       = us-west-2
 
 [OTHER]
 log_level = INFO
-log_format = "%(levelname)s %(threadName)s %(name)s:%(funcName)s %(message)s"
+log_format = '%(levelname)s %(threadName)s %(name)s:%(funcName)s %(message)s'
 log_group_name = "/pds/nucleus/dum/client-log-group"

--- a/src/pds/ingress/util/conf.default.ini
+++ b/src/pds/ingress/util/conf.default.ini
@@ -18,4 +18,4 @@ region       = us-west-2
 [OTHER]
 log_level = INFO
 log_format = "%(levelname)s %(threadName)s %(name)s:%(funcName)s %(message)s"
-log_group_name = "PDSDataUploadManagerLogGroup"
+log_group_name = "/pds/nucleus/dum/client-log-group"

--- a/tests/pds/ingress/util/test_config_util.py
+++ b/tests/pds/ingress/util/test_config_util.py
@@ -2,12 +2,15 @@
 import unittest
 
 from pds.ingress.util.config_util import ConfigUtil
+from pds.ingress.util.config_util import SanitizingConfigParser
 
 
 class ConfigUtilTest(unittest.TestCase):
     def test_default_config(self):
         """Test with the default configuration file"""
         parser = ConfigUtil.get_config()
+
+        self.assertIsInstance(parser, SanitizingConfigParser)
 
         self.assertEqual(parser["AWS"]["profile"], "AWS_Profile_1234")
 
@@ -25,6 +28,18 @@ class ConfigUtilTest(unittest.TestCase):
         self.assertEqual(parser["COGNITO"]["region"], "us-west-2")
 
         self.assertEqual(parser["OTHER"]["log_level"], "INFO")
+        self.assertEqual(
+            parser["OTHER"]["log_format"], "%(levelname)s %(threadName)s %(name)s:%(funcName)s %(message)s"
+        )
+        self.assertEqual(parser["OTHER"]["log_group_name"], "/pds/nucleus/dum/client-log-group")
+
+        # Ensure the sanitizing config parser removed any quotes surrounding
+        # values within the config
+        self.assertFalse(parser["OTHER"]["log_format"].startswith("'"))
+        self.assertFalse(parser["OTHER"]["log_format"].endswith("'"))
+
+        self.assertFalse(parser["OTHER"]["log_group_name"].startswith('"'))
+        self.assertFalse(parser["OTHER"]["log_group_name"].endswith('"'))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->

## 🗒️ Summary
This branch addresses an issue where quotes included for values in the provided INI config were not properly sanitized out after being parsed. This could result in quote characters being included for JSON serialization when providing a parsed config field within an HTTP request payload.

A new `SanitizingConfigParser` class has been added, which inherits most of its functionality from the baseline `RawConfigParser`, but adds an additional step to sanitize any parsed values before being returned. Currently, this only includes removal of both single- and double-quotes from any strings.

Lastly, some minor fixes are made to the documentation to correct some inaccuracies in the section on venv installation.

## ⚙️ Test Data and/or Report
* Unit tests for config parsing have been updated to test the functionality of the new `SanitizingConfigParser` class
* Test transfers to the MCP Test environment were also tested to ensure usage of a config file with quoted values does not cause logging to CloudWatch to break

## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->
Fixes #110 


