### PR TITLE
Add support for forcible overwrite of files and version checking between client and service

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -169,7 +169,7 @@
         "filename": "tests/pds/ingress/service/test_pds_ingress_app.py",
         "hashed_secret": "727d8ff68b6b550f2cf6e737b3cad5149c65fe5b",
         "is_verified": false,
-        "line_number": 82
+        "line_number": 124
       }
     ],
     "tests/pds/ingress/util/test_auth_util.py": [
@@ -189,5 +189,5 @@
       }
     ]
   },
-  "generated_at": "2024-04-18T20:17:41Z"
+  "generated_at": "2024-06-12T20:47:15Z"
 }

--- a/src/pds/ingress/client/pds_ingress_client.py
+++ b/src/pds/ingress/client/pds_ingress_client.py
@@ -21,6 +21,7 @@ import pds.ingress.util.log_util as log_util
 import requests
 from joblib import delayed
 from joblib import Parallel
+from pds.ingress import __version__
 from pds.ingress.util.auth_util import AuthUtil
 from pds.ingress.util.config_util import ConfigUtil
 from pds.ingress.util.log_util import get_log_level
@@ -263,6 +264,7 @@ def request_file_for_ingress(object_body, ingress_path, trimmed_path, node_id, f
         "ContentLength": str(file_size),
         "LastModified": str(last_modified_time),
         "ForceOverwrite": str(int(force_overwrite)),
+        "ClientVersion": __version__,
         "content-type": "application/json",
         "x-amz-docs-region": api_gateway_region,
     }

--- a/src/pds/ingress/client/pds_ingress_client.py
+++ b/src/pds/ingress/client/pds_ingress_client.py
@@ -269,7 +269,6 @@ def request_file_for_ingress(object_body, ingress_path, trimmed_path, node_id, f
     }
 
     response = requests.post(api_gateway_url, params=params, data=json.dumps(payload), headers=headers)
-    response.raise_for_status()
 
     # Ingress request successful
     if response.status_code == 200:
@@ -283,8 +282,10 @@ def request_file_for_ingress(object_body, ingress_path, trimmed_path, node_id, f
         logger.info("%s : File already exists unchanged on S3, skipping ingress", trimmed_path)
 
         return None
+    elif response.status_code == 404:
+        logger.warning('%s : Service returned 404 with message "%s"', trimmed_path, response.text)
     else:
-        raise RuntimeError(f"Unexpected status code ({response.status_code}) returned from ingress request")
+        response.raise_for_status()
 
 
 @backoff.on_exception(

--- a/src/pds/ingress/client/pds_ingress_client.py
+++ b/src/pds/ingress/client/pds_ingress_client.py
@@ -482,6 +482,12 @@ def setup_argparser():
         "is used instead.",
     )
     parser.add_argument(
+        "--version",
+        action="version",
+        version=f"Data Upload Manager v{__version__}",
+        help="Print the Data Upload Manager release version and exit.",
+    )
+    parser.add_argument(
         "ingress_paths",
         type=str,
         nargs="+",

--- a/src/pds/ingress/client/pds_ingress_client.py
+++ b/src/pds/ingress/client/pds_ingress_client.py
@@ -61,10 +61,9 @@ def backoff_logger(details):
     """Log details about the current backoff/retry"""
     logger = get_logger(__name__)
     logger.warning(
-        f"Backing off {details['target']} function for {details['wait']:0.1f} "
-        f"seconds after {details['tries']} tries."
+        "Backing off %s function for %.1f seconds after %d tries.", details["target"], details["wait"], details["tries"]
     )
-    logger.warning(f"Total time elapsed: {details['elapsed']:0.1f} seconds.")
+    logger.warning("Total time elapsed: %.1f seconds.", details["elapsed"])
 
 
 def _perform_ingress(ingress_path, node_id, prefix, force_overwrite, api_gateway_config):
@@ -114,10 +113,10 @@ def _perform_ingress(ingress_path, node_id, prefix, force_overwrite, api_gateway
         # Only log the error as a warning, so we don't bring down the entire
         # transfer process
         reason = err.response.json() if isinstance(err, requests.exceptions.HTTPError) else str(err)
-        logger.warning(f"{trimmed_path} : Ingress failed, reason: {reason}")
+        logger.warning("%s : Ingress failed, reason: %s", trimmed_path, reason)
         SUMMARY_TABLE["failed"].add(trimmed_path)
     finally:
-        logger.debug(f"Deallocating memory for {trimmed_path} ({len(object_body)} bytes)")
+        logger.debug("Deallocating memory for %s (%d bytes)", trimmed_path, len(object_body))
         del object_body
 
 
@@ -235,7 +234,7 @@ def request_file_for_ingress(object_body, ingress_path, trimmed_path, node_id, f
 
     logger = get_logger(__name__)
 
-    logger.info(f"{trimmed_path} : Requesting ingress for node ID {node_id}")
+    logger.info("%s : Requesting ingress for node ID %s", trimmed_path, node_id)
 
     # Extract the API Gateway configuration params
     api_gateway_template = api_gateway_config["url_template"]
@@ -276,12 +275,12 @@ def request_file_for_ingress(object_body, ingress_path, trimmed_path, node_id, f
     if response.status_code == 200:
         s3_ingress_url = json.loads(response.text)
 
-        logger.debug(f"{trimmed_path} : Got URL for ingress path {s3_ingress_url.split('?')[0]}")
+        logger.debug("%s : Got URL for ingress path %s", trimmed_path, s3_ingress_url.split("?")[0])
 
         return s3_ingress_url
     # Ingress service indiciates file already exists in S3 and should not be overwritten
     elif response.status_code == 204:
-        logger.info(f"{trimmed_path} : File already exists unchanged on S3, skipping ingress")
+        logger.info("%s : File already exists unchanged on S3, skipping ingress", trimmed_path)
 
         return None
     else:
@@ -320,12 +319,12 @@ def ingress_file_to_s3(object_body, ingress_path, trimmed_path, s3_ingress_url):
     """
     logger = get_logger(__name__)
 
-    logger.info(f"{trimmed_path} : Ingesting to {s3_ingress_url.split('?')[0]}")
+    logger.info("%s: Ingesting to %s", trimmed_path, s3_ingress_url.split("?")[0])
 
     response = requests.put(s3_ingress_url, data=object_body)
     response.raise_for_status()
 
-    logger.info(f"{trimmed_path} : Ingest complete")
+    logger.info("%s : Ingest complete", trimmed_path)
 
     # Update total number of bytes transferrred
     SUMMARY_TABLE["transferred"] += os.stat(ingress_path).st_size
@@ -522,7 +521,7 @@ def main():
 
     logger = get_logger(__name__, log_level=get_log_level(args.log_level))
 
-    logger.info(f"Loaded config file {args.config_path}")
+    logger.info("Loaded config file %s", args.config_path)
 
     # Derive the full list of ingress paths based on the set of paths requested
     # by the user

--- a/src/pds/ingress/service/config/VERSION.txt
+++ b/src/pds/ingress/service/config/VERSION.txt
@@ -1,0 +1,1 @@
+../../VERSION.txt

--- a/src/pds/ingress/service/pds_ingress_app.py
+++ b/src/pds/ingress/service/pds_ingress_app.py
@@ -326,7 +326,7 @@ def lambda_handler(event, context):
     if not bucket_exists(destination_bucket):
         return {
             "statusCode": 404,
-            "message": f"Bucket {destination_bucket} does not exist or has insufficient access permisisons",
+            "body": f"Bucket {destination_bucket} does not exist or has insufficient access permisisons",
         }
 
     object_key = join(request_node.lower(), local_url)

--- a/src/pds/ingress/service/pds_ingress_app.py
+++ b/src/pds/ingress/service/pds_ingress_app.py
@@ -127,6 +127,13 @@ def should_overwrite_file(destination_bucket, object_key, headers):
     True if overwrite (or write) should occur, False otherwise.
 
     """
+    # First, check if the client has specified the "force overwite" option
+    if bool(int(headers.get("ForceOverwrite", False))):
+        logger.info("Client has specified force overwrite")
+        return True
+
+    # Next, check if the file already exists within the S3 bucket designated by
+    # the bucket map
     try:
         object_head = s3_client.head_object(Bucket=destination_bucket, Key=object_key)
     except botocore.exceptions.ClientError as e:

--- a/src/pds/ingress/util/auth_util.py
+++ b/src/pds/ingress/util/auth_util.py
@@ -48,7 +48,7 @@ class AuthUtil:
 
         auth_params = {"USERNAME": cognito_config["username"], "PASSWORD": cognito_config["password"]}
 
-        logger.info(f"Performing Cognito authentication for user {cognito_config['username']}")
+        logger.info("Performing Cognito authentication for user %s", cognito_config["username"])
 
         try:
             response = client.initiate_auth(

--- a/src/pds/ingress/util/log_util.py
+++ b/src/pds/ingress/util/log_util.py
@@ -252,7 +252,7 @@ class CloudWatchHandler(BufferingHandler):
         except Exception as err:
             # Use the root logger since the console logger singleton may have been
             # closed by the time flush() is called
-            logging.warning(f"Unable to submit to CloudWatch Logs, reason: {str(err)}")
+            logging.warning("Unable to submit to CloudWatch Logs, reason: %s", str(err))
         finally:
             self.release()
 

--- a/src/pds/ingress/util/path_util.py
+++ b/src/pds/ingress/util/path_util.py
@@ -45,15 +45,15 @@ class PathUtil:
             abs_user_path = os.path.abspath(user_path)
 
             if not os.path.exists(abs_user_path):
-                logger.warning(f"Encountered path ({abs_user_path}) that does not actually exist, skipping...")
+                logger.warning("Encountered path (%s) that does not actually exist, skipping...", abs_user_path)
                 continue
 
             if os.path.isfile(abs_user_path):
-                logger.debug(f"Resolved path {abs_user_path}")
+                logger.debug("Resolved path %s", abs_user_path)
 
                 resolved_paths.append(abs_user_path)
             elif os.path.isdir(abs_user_path):
-                logger.debug(f"Resolving directory {abs_user_path}")
+                logger.debug("Resolving directory %s", abs_user_path)
                 for grouping in os.walk(abs_user_path, topdown=True, followlinks=True):
                     dirpath, _, filenames = grouping
 
@@ -66,7 +66,7 @@ class PathUtil:
 
                     resolved_paths = PathUtil.resolve_ingress_paths(product_paths, resolved_paths)
             else:
-                logger.warning(f"Encountered path ({abs_user_path}) that is neither a file nor directory, skipping...")
+                logger.warning("Encountered path (%s) that is neither a file nor directory, skipping...", abs_user_path)
 
         return resolved_paths
 
@@ -104,6 +104,6 @@ class PathUtil:
             if trimmed_ingress_path.startswith("/"):
                 trimmed_ingress_path = trimmed_ingress_path[1:]
 
-            logger.debug(f"Removed prefix {prefix}, new path: {trimmed_ingress_path}")
+            logger.debug("Removed prefix %s, new path: %s", prefix, trimmed_ingress_path)
 
         return trimmed_ingress_path

--- a/terraform/modules/lambda/service/ingress_service.tf
+++ b/terraform/modules/lambda/service/ingress_service.tf
@@ -77,7 +77,7 @@ resource "aws_lambda_function" "lambda_ingress_service" {
       BUCKET_MAP_LOCATION = "config",
       LOG_LEVEL           = "INFO",
       VERSION_LOCATION    = "config",
-      VERSION_FILe        = "VERSION.txt"
+      VERSION_FILE        = "VERSION.txt"
     }
   }
 }

--- a/terraform/modules/lambda/service/ingress_service.tf
+++ b/terraform/modules/lambda/service/ingress_service.tf
@@ -74,8 +74,10 @@ resource "aws_lambda_function" "lambda_ingress_service" {
   environment {
     variables = {
       BUCKET_MAP_FILE     = "bucket-map.yaml",
-      BUCKET_MAP_LOCATION = "config"
-      LOG_LEVEL           = "INFO"
+      BUCKET_MAP_LOCATION = "config",
+      LOG_LEVEL           = "INFO",
+      VERSION_LOCATION    = "config",
+      VERSION_FILe        = "VERSION.txt"
     }
   }
 }

--- a/tests/pds/ingress/service/test_pds_ingress_app.py
+++ b/tests/pds/ingress/service/test_pds_ingress_app.py
@@ -13,8 +13,12 @@ from unittest.mock import patch
 import boto3
 import botocore.client
 import botocore.exceptions
+from pds.ingress import __version__
+from pds.ingress.service.pds_ingress_app import check_client_version
+from pds.ingress.service.pds_ingress_app import get_dum_version
 from pds.ingress.service.pds_ingress_app import initialize_bucket_map
 from pds.ingress.service.pds_ingress_app import lambda_handler
+from pds.ingress.service.pds_ingress_app import logger as service_logger
 from pds.ingress.service.pds_ingress_app import should_overwrite_file
 from pkg_resources import resource_filename
 
@@ -31,6 +35,16 @@ class PDSIngressAppTest(unittest.TestCase):
         )
         os.environ["BUCKET_MAP_LOCATION"] = "config"
         os.environ["BUCKET_MAP_FILE"] = "bucket-map.yaml"
+        os.environ["VERSION_LOCATION"] = "config"
+        os.environ["VERSION_FILE"] = "VERSION.txt"
+
+    def test_get_dum_version(self):
+        """Test parsing of the version number from the bundled VERSION.txt"""
+        version = get_dum_version()
+
+        # Version read from bundled file should always match what was parsed into
+        # the __init__.py module for the pds.ingress package
+        self.assertEqual(version, __version__)
 
     def test_default_bucket_map(self):
         """Test parsing of the default bucket map bundled with the Lambda function"""
@@ -73,6 +87,34 @@ class PDSIngressAppTest(unittest.TestCase):
             self.assertIn("ENG", bucket_map["MAP"]["NODES"])
             self.assertIn("default", bucket_map["MAP"]["NODES"]["ENG"])
             self.assertEqual(bucket_map["MAP"]["NODES"]["ENG"]["default"], "test-bucket-name")
+
+    def test_check_client_version(self):
+        """Test the logging that occurs during the client version check"""
+        # Check matching case
+        with self.assertLogs(logger=service_logger, level="INFO") as cm:
+            check_client_version(client_version=__version__, service_version=__version__)
+
+        # Make sure we get the expected number of log messages
+        self.assertEqual(len(cm.output), 1)
+
+        # Logger object used in a deployed Lambda function comes with its own
+        # built-in formatter, so we need to do a substring match here rather than
+        # a straight comparison
+        self.assertIn(f"DUM client version ({__version__}) matches ingress service", cm.output[0])
+
+        # Check missing version from client
+        with self.assertLogs(logger=service_logger, level="WARNING") as cm:
+            check_client_version(client_version=None, service_version=__version__)
+
+        self.assertEqual(len(cm.output), 1)
+        self.assertIn("No DUM version provided by client", cm.output[0])
+
+        # Check client/serivce mismatch
+        with self.assertLogs(logger=service_logger, level="WARNING") as cm:
+            check_client_version(client_version="0.0.0", service_version=__version__)
+
+        self.assertEqual(len(cm.output), 1)
+        self.assertIn(f"Version mismatch between client (0.0.0) and service ({__version__})", cm.output[0])
 
     # Hard-wire some fake credentials into the S3 client so botocore has something
     # to use in environments that have no credentials otherwise (such as GitHub Actions)

--- a/tests/pds/ingress/service/test_pds_ingress_app.py
+++ b/tests/pds/ingress/service/test_pds_ingress_app.py
@@ -177,14 +177,20 @@ class PDSIngressAppTest(unittest.TestCase):
 
     def test_should_overwrite_file(self):
         """Test check for overwrite of prexisting file in S3"""
+        # Test inclusion of ForceOverwrite flag
+        test_headers = {"ForceOverwrite": True}
+        bucket = "sample_bucket"
+        key = "path/to/sample_file"
+
+        self.assertTrue(should_overwrite_file(bucket, key, test_headers))
+
         # Create sample data sent by client script
         test_headers = {
             "ContentLength": os.stat(os.path.abspath(__file__)).st_size,
             "ContentMD5": "validhash",
             "LastModified": os.path.getmtime(os.path.abspath(__file__)),
+            "ForceOverwrite": False,
         }
-        bucket = "sample_bucket"
-        key = "path/to/sample_file"
 
         # Setup mock return values for head_object, one which matches the requested
         # file exactly, and one that does not


### PR DESCRIPTION
<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->

## 🗒️ Summary
This branch adds the following features to the DUM package:

- Users can now specify a `--force-overwrite` flag to the client script to force ingest of all requested files, even if they already exist unchanged in S3 (support for checking registry to come later)
- The client script now provides a `--version` flag to check the installed version of the DUM package
- The client provides its version number with each request to the Lambda service. The Lambda service now checks to see if there is a mismatch between its version (bundled with the Lambda) and the version sent by the client. If there is a mismatch, it is logged, but the request is allowed to proceed.

This branch also fixes a bug related to reporting when an ingress request is mapped to a non-existing bucket, and standardizes all logging calls to use traditional format strings instead of f-strings.

## ⚙️ Test Data and/or Report
* Unit tests for the service function have been updated to test new functionality
* The updated service function has been deployed in the MCP dev environment, and tested using the latest client script from this branch

## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->
Resolves (partially) #100 

