### PR TITLE
User defined metadata for uploaded S3 products

### DIFF
--- a/src/pds/ingress/service/pds_ingress_app.py
+++ b/src/pds/ingress/service/pds_ingress_app.py
@@ -157,7 +157,6 @@ def bucket_exists(destination_bucket):
 
     """
     try:
-        s3_client = boto3.client("s3")
         s3_client.head_bucket(Bucket=destination_bucket)
     except botocore.exceptions.ClientError as e:
         logger.warning("Check for bucket %s returned code %s", destination_bucket, e.response["Error"]["Code"])
@@ -200,7 +199,6 @@ def should_overwrite_file(destination_bucket, object_key, md5_digest, file_size,
     # Next, check if the file already exists within the S3 bucket designated by
     # the bucket map
     try:
-        s3_client = boto3.client("s3")
         object_head = s3_client.head_object(Bucket=destination_bucket, Key=object_key)
     except botocore.exceptions.ClientError as e:
         if e.response["Error"]["Code"] == "404":
@@ -289,7 +287,6 @@ def generate_presigned_upload_url(
     }
 
     try:
-        s3_client = boto3.client("s3")
         url = s3_client.generate_presigned_url(
             ClientMethod=client_method, Params=method_parameters, ExpiresIn=expires_in
         )

--- a/tests/pds/ingress/service/test_pds_ingress_app.py
+++ b/tests/pds/ingress/service/test_pds_ingress_app.py
@@ -128,6 +128,7 @@ class PDSIngressAppTest(unittest.TestCase):
                         "ingress_path": "/home/user/data/gbo.ast.catalina.survey/bundle_gbo.ast.catalina.survey_v1.0.xml",
                         "trimmed_path": "gbo.ast.catalina.survey/bundle_gbo.ast.catalina.survey_v1.0.xml",
                         "md5": "fakehashfakehashfakehash",
+                        "base64_md5": "fakehashfakehash==",
                         "size": 1,
                         "last_modified": os.path.getmtime(os.path.abspath(__file__)),
                     }
@@ -181,6 +182,7 @@ class PDSIngressAppTest(unittest.TestCase):
                         "ingress_path": "/home/user/data/some.other.survey/bundle.some.other.survey_v1.0.xml",
                         "trimmed_path": "some.other.survey/bundle.some.other.survey_v1.0.xml",
                         "md5": "fakehashfakehashfakehash",
+                        "base64_md5": "fakehashfakehash==",
                         "size": 1,
                         "last_modified": os.path.getmtime(os.path.abspath(__file__)),
                     }
@@ -218,6 +220,7 @@ class PDSIngressAppTest(unittest.TestCase):
                         "ingress_path": "/home/user/data/gbo.ast.catalina.survey/bundle_gbo.ast.catalina.survey_v1.0.xml",
                         "trimmed_path": "gbo.ast.catalina.survey/bundle_gbo.ast.catalina.survey_v1.0.xml",
                         "md5": "fakehashfakehashfakehash",
+                        "base64_md5": "fakehashfakehash==",
                         "size": 1,
                         "last_modified": os.path.getmtime(os.path.abspath(__file__)),
                     }
@@ -237,6 +240,7 @@ class PDSIngressAppTest(unittest.TestCase):
                         "ingress_path": "/home/user/data/gbo.ast.catalina.survey/bundle_gbo.ast.catalina.survey_v1.0.xml",
                         "trimmed_path": "gbo.ast.catalina.survey/bundle_gbo.ast.catalina.survey_v1.0.xml",
                         "md5": "fakehashfakehashfakehash",
+                        "base64_md5": "fakehashfakehash==",
                         "size": 1,
                         "last_modified": os.path.getmtime(os.path.abspath(__file__)),
                     }


### PR DESCRIPTION
<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->

## 🗒️ Summary
This PR enhances the DUM service to include several user-defined metadata fields with the pre-signed URLs returned to the client. These user-defined fields become associated with the uploaded file once in S3, and can be viewed from the console:

<img width="1664" alt="Screenshot 2024-07-23 at 2 43 41 PM" src="https://github.com/user-attachments/assets/63e9f89e-3162-4b2e-8a8a-4990502f90ae">

This branch also adds inclusion of the MD5 digest of an uploaded file with the pre-signed URL, so that AWS can validate the integrity of uploaded files automatically at time of ingest to S3.

## ⚙️ Test Data and/or Report
Unit test suite has been updated to accommodate changes to the request payload structure.
New features have been tested in MCP dev environment to verify user-defined metadata is now associated to uploaded S3 objects.

## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->
Resolves #87 
Resolves #50 

