### PR TITLE
CloudWatch Logging and Backoff/Retry bug fixes

### DIFF
--- a/src/pds/ingress/client/pds_ingress_client.py
+++ b/src/pds/ingress/client/pds_ingress_client.py
@@ -53,9 +53,19 @@ SUMMARY_TABLE = {
 
 
 def fatal_code(err: requests.exceptions.RequestException) -> bool:
-    """Only retry for common transient errors"""
+    """
+    Determines if the HTTP return code associated with a requests exception
+    corresponds to a fatal error or not. If the error is of a transient nature,
+    this function will return False, indicating to the backoff decorator that
+    the reqeust should be retried. Otherwise, a return value of True will
+    cause any backoff/reties to be abandoned.
+    """
     if err.response is not None:
-        return 400 <= err.response.status_code < 500
+        # HTTP codes indicating a transient error (including throttling) which
+        # are worth retrying after a backoff
+        transient_codes = [408, 425, 429, 500, 502, 503, 504, 509]
+
+        return err.response.status_code not in transient_codes
     else:
         # No response to interrogate, so default to no retry
         return True

--- a/src/pds/ingress/service/pds_ingress_app.py
+++ b/src/pds/ingress/service/pds_ingress_app.py
@@ -11,6 +11,7 @@ import logging
 import os
 from datetime import datetime
 from datetime import timezone
+from http import HTTPStatus
 from os.path import join
 
 import boto3
@@ -375,7 +376,7 @@ def lambda_handler(event, context):
         if not bucket_exists(destination_bucket):
             result.append(
                 {
-                    "result": 404,
+                    "result": HTTPStatus.NOT_FOUND,
                     "local_url": trimmed_path,
                     "s3_url": None,
                     "message": f"Mapped bucket {destination_bucket} does not exist or has insufficient access permisisons",
@@ -399,7 +400,7 @@ def lambda_handler(event, context):
 
                 result.append(
                     {
-                        "result": 200,
+                        "result": HTTPStatus.OK,
                         "trimmed_path": trimmed_path,
                         "ingress_path": ingress_path,
                         "md5": md5_digest,
@@ -414,7 +415,12 @@ def lambda_handler(event, context):
                 )
 
                 result.append(
-                    {"result": 204, "trimmed_path": trimmed_path, "s3_url": None, "message": "File already exists"}
+                    {
+                        "result": HTTPStatus.NO_CONTENT,
+                        "trimmed_path": trimmed_path,
+                        "s3_url": None,
+                        "message": "File already exists",
+                    }
                 )
 
-    return {"statusCode": 200, "body": json.dumps(result)}
+    return {"statusCode": HTTPStatus.OK, "body": json.dumps(result)}

--- a/src/pds/ingress/util/backoff_util.py
+++ b/src/pds/ingress/util/backoff_util.py
@@ -1,0 +1,29 @@
+"""
+===============
+backoff_util.py
+===============
+
+Module containing functions related to utilization of the backoff module for
+automatic backoff/retry of HTTP requests.
+
+"""
+import requests
+
+
+def fatal_code(err: requests.exceptions.RequestException) -> bool:
+    """
+    Determines if the HTTP return code associated with a requests exception
+    corresponds to a fatal error or not. If the error is of a transient nature,
+    this function will return False, indicating to the backoff decorator that
+    the reqeust should be retried. Otherwise, a return value of True will
+    cause any backoff/reties to be abandoned.
+    """
+    if err.response is not None:
+        # HTTP codes indicating a transient error (including throttling) which
+        # are worth retrying after a backoff
+        transient_codes = [408, 425, 429, 500, 502, 503, 504, 509]
+
+        return err.response.status_code not in transient_codes
+    else:
+        # No response to interrogate, so default to no retry
+        return True

--- a/src/pds/ingress/util/backoff_util.py
+++ b/src/pds/ingress/util/backoff_util.py
@@ -7,6 +7,8 @@ Module containing functions related to utilization of the backoff module for
 automatic backoff/retry of HTTP requests.
 
 """
+from http import HTTPStatus
+
 import requests
 
 
@@ -21,7 +23,16 @@ def fatal_code(err: requests.exceptions.RequestException) -> bool:
     if err.response is not None:
         # HTTP codes indicating a transient error (including throttling) which
         # are worth retrying after a backoff
-        transient_codes = [408, 425, 429, 500, 502, 503, 504, 509]
+        transient_codes = [
+            HTTPStatus.REQUEST_TIMEOUT,
+            HTTPStatus.TOO_EARLY,
+            HTTPStatus.TOO_MANY_REQUESTS,
+            HTTPStatus.INTERNAL_SERVER_ERROR,
+            HTTPStatus.BAD_GATEWAY,
+            HTTPStatus.SERVICE_UNAVAILABLE,
+            HTTPStatus.GATEWAY_TIMEOUT,
+            509,  # Bandwidth Limit Exceeded (non-standard code used by AWS)
+        ]
 
         return err.response.status_code not in transient_codes
     else:

--- a/tests/pds/ingress/util/test_log_util.py
+++ b/tests/pds/ingress/util/test_log_util.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import json as json_module
 import unittest
+from http import HTTPStatus
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
@@ -114,7 +115,7 @@ class LogUtilTest(unittest.TestCase):
             self.assertEqual(headers["UserGroup"], NodeUtil.node_id_to_group_name("eng"))
 
             response = requests.Response()
-            response.status_code = 200
+            response.status_code = HTTPStatus.OK
 
             return response
 
@@ -135,21 +136,32 @@ class LogUtilTest(unittest.TestCase):
 
         # Set up some canned HTTP responses for the transient error codes we retry for
         response_408 = Response()
-        response_408.status_code = 408
+        response_408.status_code = HTTPStatus.REQUEST_TIMEOUT
         response_425 = Response()
-        response_425.status_code = 425
+        response_425.status_code = HTTPStatus.TOO_EARLY
         response_429 = Response()
-        response_429.status_code = 429
+        response_429.status_code = HTTPStatus.TOO_MANY_REQUESTS
         response_500 = Response()
-        response_500.status_code = 500
+        response_500.status_code = HTTPStatus.INTERNAL_SERVER_ERROR
         response_502 = Response()
-        response_502.status_code = 502
+        response_502.status_code = HTTPStatus.BAD_GATEWAY
         response_503 = Response()
-        response_503.status_code = 503
+        response_503.status_code = HTTPStatus.SERVICE_UNAVAILABLE
         response_504 = Response()
-        response_504.status_code = 504
+        response_504.status_code = HTTPStatus.GATEWAY_TIMEOUT
+        response_509 = Response()
+        response_509.status_code = 509  # Bandwidth Limit Exceeded (non-standard code used by AWS)
 
-        responses = [response_408, response_425, response_429, response_500, response_502, response_503, response_504]
+        responses = [
+            response_408,
+            response_425,
+            response_429,
+            response_500,
+            response_502,
+            response_503,
+            response_504,
+            response_509,
+        ]
 
         # Set up a Mock function for session.get which will cycle through all
         # transient error codes before finally returning success (200)


### PR DESCRIPTION
<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->

## 🗒️ Summary
This branch makes a number of modifications to how logs are submitted to CloudWatch to fix the following issues:

- Log level reverts to DEBUG whenever sending logs to CloudWatch fails for any reason
- The "giveup" function used with the backoff/retry decorator(s) does not properly handle all types of recoverable HTTP errors

The logging that occurs when a CloudWatch Logs send fails now utilizes a specialized "console-only" logger, rather than using the default "root" logger. Use of the "root" logger seemed to be the trigger that reset the global logging level to DEBUG. The `send_logs_to_cloud_watch` function is now properly wrapped with a backoff/retry decorator to further minimize any sporadic failures that might occur during regular flushing of logs to AWS.

The "giveup" function used with all backoff decorators now looks for specific HTTP codes that indicate a recoverable error (temporary server side unavailability or request throttling from AWS). This should also help to minimize the number of failed file uploads during regular usage of DUM.

## ⚙️ Test Data and/or Report
Unit tests for the logging utilities have been updated to account for changes made, and a new test has been added for usage of the backoff/retry decorator when submitting logs to CloudWatch.

This branch has also been deployed and tested on MCP dev as a manual integration test.

## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->
Fixes #135 
Fixes #136 

