### PR TITLE
Refinements to request batching, error retries and logging

### DIFF
--- a/src/pds/ingress/client/pds_ingress_client.py
+++ b/src/pds/ingress/client/pds_ingress_client.py
@@ -95,7 +95,9 @@ def perform_ingress(batched_ingress_paths, node_id, prefix, force_overwrite, api
         # Perform uploads to S3 in parallel based on number of files
         PARALLEL(delayed(ingress_file_to_s3)(ingress_response) for ingress_response in chain(*response_batches))
     except RequestException as err:
-        logger.error("Ingress failed, HTTP response text:\n%s", err.response.text)
+        logger.error(
+            "Ingress failed, HTTP code: %d\n HTTP response text:\n%s", err.response.status_code, err.response.text
+        )
         raise
     except Exception as err:
         logger.error("Ingress failed, reason: %s", str(err))

--- a/src/pds/ingress/service/pds_ingress_app.py
+++ b/src/pds/ingress/service/pds_ingress_app.py
@@ -377,7 +377,7 @@ def lambda_handler(event, context):
             result.append(
                 {
                     "result": HTTPStatus.NOT_FOUND,
-                    "local_url": trimmed_path,
+                    "trimmed_path": trimmed_path,
                     "s3_url": None,
                     "message": f"Mapped bucket {destination_bucket} does not exist or has insufficient access permisisons",
                 }

--- a/src/pds/ingress/service/pds_ingress_app.py
+++ b/src/pds/ingress/service/pds_ingress_app.py
@@ -240,7 +240,7 @@ def generate_presigned_upload_url(
     last_modified,
     client_version,
     service_version,
-    expires_in=1000,
+    expires_in=3000,
 ):
     """
     Generates a presigned URL suitable for uploading to the S3 location
@@ -263,9 +263,9 @@ def generate_presigned_upload_url(
         Version of the DUM client used to initiate the ingress reqeust.
     service_version : str
         Version of the DUM lambda service used to process this ingress request.
-    expires_in : int
+    expires_in : int, optional
         Expiration time of the generated URL in seconds. After this time,
-        the URL should no longer be valid.
+        the URL should no longer be valid. Defaults to 3000 seconds.
 
     Returns
     -------

--- a/src/pds/ingress/util/backoff_util.py
+++ b/src/pds/ingress/util/backoff_util.py
@@ -24,6 +24,7 @@ def fatal_code(err: requests.exceptions.RequestException) -> bool:
         # HTTP codes indicating a transient error (including throttling) which
         # are worth retrying after a backoff
         transient_codes = [
+            HTTPStatus.BAD_REQUEST,
             HTTPStatus.REQUEST_TIMEOUT,
             HTTPStatus.TOO_EARLY,
             HTTPStatus.TOO_MANY_REQUESTS,


### PR DESCRIPTION
<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->

## 🗒️ Summary
This branch makes a number of enhancements to how ingress requests are processed as batches to further reduce overhead from prep and submission of batch requests. Previously, processing of batches used separate thread pools for each stage (prep, request submission and upload), which could cause threads to go unused towards the end of each stage. One thread pool is now used to handle all stages so that better thread utilization can be achieved.

Additionally, this branch makes several updates to logging to indicate the batch being worked on. The summary reports are now always created (if enabled), even if the client does not exit gracefully (due to `KeyboardInterrupt` or similar).

Lastly, there are also some minor changes to the backoff/retry determination logic to try to catch additional cases that could be recoverable during a transfer.

## ⚙️ Test Data and/or Report
Updates have been deployed and tested both on MCP Dev and Test

## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->


