### PR TITLE
Added progress bar during resolution of ingress paths and fixed issues with logs sent to CloudWatch

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,7 @@ install_requires =
     requests>=2.23
     types-requests>=2.23
     PyYAML~=6.0
+    tqdm~=4.67.0
     types-PyYAML~=6.0
 
 # Change this to False if you use things like __file__ or __path__—which you

--- a/src/pds/ingress/client/pds_ingress_client.py
+++ b/src/pds/ingress/client/pds_ingress_client.py
@@ -634,7 +634,9 @@ def main(args):
 
     # Derive the full list of ingress paths based on the set of paths requested
     # by the user
-    resolved_ingress_paths = PathUtil.resolve_ingress_paths(args.ingress_paths)
+    logger.info("Determining paths for ingress...")
+    with PathUtil.init_path_progress_bar(args.ingress_paths) as pbar:
+        resolved_ingress_paths = PathUtil.resolve_ingress_paths(args.ingress_paths, pbar)
 
     node_id = args.node
 

--- a/src/pds/ingress/util/log_util.py
+++ b/src/pds/ingress/util/log_util.py
@@ -212,7 +212,7 @@ class CloudWatchHandler(BufferingHandler):
 
     """
 
-    def __init__(self, log_group_name, api_gateway_config, capacity=1024):
+    def __init__(self, log_group_name, api_gateway_config, capacity=512):
         super().__init__(capacity)
 
         self.log_group_name = log_group_name

--- a/src/pds/ingress/util/log_util.py
+++ b/src/pds/ingress/util/log_util.py
@@ -220,6 +220,7 @@ class CloudWatchHandler(BufferingHandler):
         self.creation_time = datetime.now().strftime("%s")
         self._bearer_token = None
         self._node_id = None
+        self._stream_created = False
 
     @property
     def bearer_token(self):
@@ -340,24 +341,29 @@ class CloudWatchHandler(BufferingHandler):
         api_gateway_region = self.api_gateway_config["region"]
         api_gateway_stage = self.api_gateway_config["stage"]
 
-        # Create the log stream for the current run.
-        # If the stream already exists, attempting to recreate should not raise an error.
         log_stream_name = f"pds-ingress-client-{self.node_id}-{self.creation_time}"
-        api_gateway_resource = "createstream"
-
-        api_gateway_url = api_gateway_template.format(
-            id=api_gateway_id, region=api_gateway_region, stage=api_gateway_stage, resource=api_gateway_resource
-        )
         payload = {"logGroupName": self.log_group_name, "logStreamName": log_stream_name}
-        headers = {
-            "Authorization": self.bearer_token,
-            "UserGroup": NodeUtil.node_id_to_group_name(self.node_id),
-            "content-type": "application/json",
-            "x-amz-docs-region": api_gateway_region,
-        }
 
-        response = requests.post(api_gateway_url, data=json.dumps(payload), headers=headers)
-        response.raise_for_status()
+        # Create the log stream for the current run, if it hasn't been already.
+        if not self._stream_created:
+            api_gateway_resource = "createstream"
+
+            api_gateway_url = api_gateway_template.format(
+                id=api_gateway_id, region=api_gateway_region, stage=api_gateway_stage, resource=api_gateway_resource
+            )
+
+            headers = {
+                "Authorization": self.bearer_token,
+                "UserGroup": NodeUtil.node_id_to_group_name(self.node_id),
+                "content-type": "application/json",
+                "x-amz-docs-region": api_gateway_region,
+            }
+
+            response = requests.post(api_gateway_url, data=json.dumps(payload), headers=headers)
+            response.raise_for_status()
+
+            # Can now skip this step for subsequent calls to flush()
+            self._stream_created = True
 
         # Now submit logged content to the newly created log stream
         api_gateway_resource = "log"

--- a/tests/pds/ingress/util/test_path_util.py
+++ b/tests/pds/ingress/util/test_path_util.py
@@ -42,7 +42,8 @@ class PathUtilTest(unittest.TestCase):
         os.system(f"touch {join(self.working_dir.name, 'dir_one', 'dir_two', 'low_level_file.txt')}")
 
         # Test with fully resolved paths
-        resolved_ingress_paths = PathUtil.resolve_ingress_paths([self.working_dir.name])
+        with PathUtil.init_path_progress_bar([self.working_dir.name]) as pbar:
+            resolved_ingress_paths = PathUtil.resolve_ingress_paths([self.working_dir.name], pbar)
 
         self.assertIsInstance(resolved_ingress_paths, list)
         self.assertGreater(len(resolved_ingress_paths), 0)
@@ -55,7 +56,8 @@ class PathUtilTest(unittest.TestCase):
         )
 
         # Test with a non-existent path
-        resolved_ingress_paths = PathUtil.resolve_ingress_paths(["/fake/path"])
+        with PathUtil.init_path_progress_bar(["/fake/path"]) as pbar:
+            resolved_ingress_paths = PathUtil.resolve_ingress_paths(["/fake/path"], pbar)
 
         self.assertIsInstance(resolved_ingress_paths, list)
         self.assertEqual(len(resolved_ingress_paths), 0)


### PR DESCRIPTION
<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->

## 🗒️ Summary
This branch adds a few miscellaneous improvements and fixes to the DUM Client script, including:

- Added a `tqdm` progress bar to track resolution of the full set of ingress paths based on what the user has requested. This was added based on feedback from SBN users who stated it was difficult to tell what the DUM client was doing during this initial phase of processing.
- Fixed an issue where a request to create a CloudWatch log stream was submitted on every flush of the logging handler that submits the client logs to CloudWatch.
- Modified the default capacity for the CloudWatch logging handler to 512 (from 1024) to resolve an issue where not all log messages were making into CloudWatch.

## ⚙️ Test Data and/or Report
Changes to DUM client have been tested on the MCP dev environment. The unit test suite has also been updated to account for addition of the progress bar.

## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->
N/A


