### PR TITLE
Checksum Manifest Reingestion Support

### DIFF
--- a/docs/source/installation/index.rst
+++ b/docs/source/installation/index.rst
@@ -84,8 +84,11 @@ The following may be used as a template for a new INI configuration file::
 
     [OTHER]
     log_level = INFO
-    log_format = "%(levelname)s %(threadName)s %(name)s:%(funcName)s %(message)s"
+    file_format = "[%(asctime)s] %(levelname)s %(threadName)s %(funcName)s : %(message)s"
+    cloudwatch_format = '%(levelname)s %(threadName)s %(funcName)s : %(message)s'
+    console_format = "%(message)s"
     log_group_name = "<Cloudwatch_Log_Group_Name>"
+    log_file_path =
 
 Bracketed fields within the template correspond to values which need to be filled
 in by an end-user prior to using the `pds-ingress-client` script to transfer

--- a/docs/source/usage/index.rst
+++ b/docs/source/usage/index.rst
@@ -48,9 +48,18 @@ For example, if the file ``/home/user/bundle/file.xml`` were to be uploaded, and
 ``--prefix /home/user`` were also provided, the path provided to the ingress service
 in AWS would resolve to ``bundle/file.xml``.
 
-Lastly, the ``pds-ingress-client`` by default utilizes all available CPUs on the
+The ``pds-ingress-client`` by default utilizes all available CPUs on the
 local machine to perform parallelized ingress requests to the ingress service. The exact
 number of threads can be controlled via the ``--num-threads`` argument.
+
+The client script also provides several arguments for reporting status of an ingress request:
+
+- ``--report-path`` : Specifies a path to write a detailed report file in JSON format, containing details about which files were uploaded, skipped or failed during transfer.
+- ``--manifest-path`` : Specifies a path to write the manifest of all files included in ingress request, including file checksums. This option may also be used to provide an existing Manifest file to bypass its recomputation during subsequent requests.
+- ``--log-path`` : Specifies a path to write a trace log of the ingress request which does not go to the console. Can be useful for troubleshooting tranfer failures.
+
+Lastly, the ``--version`` option may be used to verify the version number of installed DUM client.
+
 
 .. References:
 .. _installation: ../installation/index.html

--- a/src/pds/ingress/client/pds_ingress_client.py
+++ b/src/pds/ingress/client/pds_ingress_client.py
@@ -183,12 +183,15 @@ def _process_batch(batch_index, request_batch, node_id, force_overwrite, api_gat
 
     # Get an avaialble Batch progress bar to update while iterating through this
     # current batch
-    batch_pbar = get_available_batch_progress_bar(total=len(request_batch), desc=f"Batch index {batch_index}")
+    batch_pbar = get_available_batch_progress_bar(total=len(request_batch), desc=f"Requesting Batch {batch_index + 1}")
 
     try:
         response_batch = request_batch_for_ingress(
             request_batch, batch_index, node_id, force_overwrite, api_gateway_config
         )
+
+        batch_pbar.desc = f"Uploading Batch {batch_index + 1}"
+        batch_pbar.refresh()
 
         for ingress_response in response_batch:
             try:

--- a/src/pds/ingress/service/pds_ingress_app.py
+++ b/src/pds/ingress/service/pds_ingress_app.py
@@ -30,8 +30,28 @@ LEVEL_MAP = {
     "DEBUG": logging.DEBUG,
 }
 
+
+class SingleLogFilter(logging.Filter):
+    """Simple log filter to ensure each unique log message is only logged once."""
+
+    def __init__(self, name=""):
+        super().__init__(name)
+        self.logged_messages = set()
+
+    def filter(self, record):
+        """Filters out the provided log record if we've seen it before"""
+        log_message = record.getMessage()
+
+        if log_message not in self.logged_messages:
+            self.logged_messages.add(log_message)
+            return True
+
+        return False
+
+
 logger = logging.getLogger()
 logger.setLevel(LEVEL_MAP.get(LOG_LEVEL.upper(), logging.INFO))
+logger.addFilter(SingleLogFilter())
 
 logger.info("Loading function PDS Ingress Service")
 

--- a/src/pds/ingress/util/log_util.py
+++ b/src/pds/ingress/util/log_util.py
@@ -39,6 +39,24 @@ DEFAULT_FORMAT = "%(levelname)s %(threadName)s %(name)s:%(funcName)s %(message)s
 """Default log format to fall back to if not defined by the INI config."""
 
 
+class SingleLogFilter(logging.Filter):
+    """Simple log filter to ensure each unique log message is only logged once."""
+
+    def __init__(self, name=""):
+        super().__init__(name)
+        self.logged_messages = set()
+
+    def filter(self, record):
+        """Filters out the provided log record if we've seen it before"""
+        log_message = record.getMessage()
+
+        if log_message not in self.logged_messages:
+            self.logged_messages.add(log_message)
+            return True
+
+        return False
+
+
 def get_log_level(log_level):
     """Translates name of a log level to the constant used by the logging module"""
     if log_level is not None:
@@ -177,6 +195,7 @@ def setup_console_log(logger, config, log_level):
         CONSOLE_HANDLER = logging.StreamHandler(stream=sys.stdout)
         CONSOLE_HANDLER.setLevel(log_level)
         CONSOLE_HANDLER.setFormatter(log_format)
+        CONSOLE_HANDLER.addFilter(SingleLogFilter())
 
     if CONSOLE_HANDLER not in logger.handlers:
         logger.addHandler(CONSOLE_HANDLER)

--- a/src/pds/ingress/util/progress_util.py
+++ b/src/pds/ingress/util/progress_util.py
@@ -89,7 +89,7 @@ def get_manifest_progress_bar(total):
             leave=True,
             desc="Generating checksum manifest",
             colour=LIGHT_GREEN,
-            bar_format="{l_bar}{bar:60}| {n_fmt}/{total_fmt} Batches ({remaining} remaining)",
+            bar_format="{l_bar}{bar:60}| {n_fmt}/{total_fmt} Batches ({remaining} est. remaining)",
         )
 
     return MANIFEST_BAR
@@ -120,7 +120,7 @@ def get_ingress_total_progress_bar(total):
             leave=True,
             desc="Uploading Batches",
             colour=LIGHT_GREEN,
-            bar_format="{l_bar}{bar:60}| {n_fmt}/{total_fmt} Batches",
+            bar_format="{l_bar}{bar:60}| {n_fmt}/{total_fmt} Batches ({remaining} est. remaining)",
         )
 
     return TOTAL_INGRESS_BAR

--- a/src/pds/ingress/util/report_util.py
+++ b/src/pds/ingress/util/report_util.py
@@ -1,0 +1,177 @@
+"""
+==============
+report_util.py
+==============
+
+Module containing functions related to output of various report files used
+to track status of a DUM upload request.
+
+"""
+import json
+import time
+from collections import defaultdict
+from datetime import datetime
+from datetime import timezone
+from itertools import chain
+
+from pds.ingress.util.log_util import get_logger
+
+EXPECTED_MANIFEST_KEYS = ("ingress_path", "md5", "size", "last_modified")
+"""The keys we expect to find assigned to each mapping within a read manifest"""
+
+
+def initialize_summary_table():
+    """Returns a summary table initialized to its default state."""
+    return {
+        "uploaded": defaultdict(set),
+        "skipped": defaultdict(set),
+        "failed": defaultdict(set),
+        "transferred": 0,
+        "start_time": time.time(),
+        "end_time": None,
+        "batch_size": 0,
+        "num_batches": 0,
+    }
+
+
+def print_ingress_summary(summary_table):
+    """
+    Prints the summary report for last execution of the client script.
+
+    Parameters
+    ----------
+    summary_table : dict
+        Dictionary containg the summarized results of DUM ingress reqeust.
+
+    """
+    logger = get_logger("print_ingress_summary")
+
+    num_uploaded = sum(len(batch) for batch in summary_table["uploaded"].values())
+    num_skipped = sum(len(batch) for batch in summary_table["skipped"].values())
+    num_failed = sum(len(batch) for batch in summary_table["failed"].values())
+    start_time = summary_table["start_time"]
+    end_time = summary_table["end_time"]
+    transferred = summary_table["transferred"]
+
+    title = f"Ingress Summary Report for {str(datetime.now())}"
+
+    logger.info("")  # Blank line to distance report from any progress bar cleanup
+    logger.info(title)
+    logger.info("-" * len(title))
+    logger.info("Uploaded: %d file(s)", num_uploaded)
+    logger.info("Skipped: %d file(s)", num_skipped)
+    logger.info("Failed: %d file(s)", num_failed)
+    logger.info("Total: %d files(s)", num_uploaded + num_skipped + num_failed)
+    logger.info("Time elapsed: %.2f seconds", end_time - start_time)
+    logger.info("Bytes tranferred: %d", transferred)
+
+
+def read_manifest_file(manifest_path):
+    """
+    Reads manifest contents, including file checksums, from the provided
+    path. The contents of the read manifest will be used to supply file information
+    for any files in the current request which are already specified within the
+    read manifest.
+
+    Notes
+    -----
+    This function also validates the contents of the read manifest to ensure
+    the contents conform to the format expected by this version of the DUM client.
+    If the read manifest does not conform, it's contents are discarded so that
+    a new conforming version will be written to disk.
+
+    Parameters
+    ----------
+    manifest_path : str
+        Path to the manifest JSON file
+
+    """
+    logger = get_logger("read_manifest_path")
+
+    with open(manifest_path, "r") as infile:
+        manifest = json.load(infile)
+
+    # Verify the contents of the read manifest conform to what we expect for this version of DUM
+    if not all(key in manifest_entry for manifest_entry in manifest.values() for key in EXPECTED_MANIFEST_KEYS):
+        logger.warning("Provided manifest %s does not conform to expected format.", manifest_path)
+        logger.warning("A new manifest will be generated for this execution.")
+        manifest.clear()
+
+    return manifest
+
+
+def write_manifest_file(manifest, manifest_path):
+    """
+    Commits the contents of the Ingress Manifest to the provided path on disk
+    in JSON format.
+
+    This function performs some manual whitespace formatting to promote
+    readability of the output JSON file.
+
+    Parameters
+    ----------
+    manifest : dict
+        Dictionary containing the contents of the manifest to commit to disk.
+    manifest_path : str
+        Path on disk to commit the Ingress Manifest file to.
+
+    """
+    with open(manifest_path, "w") as outfile:
+        outfile.write("{\n")
+
+        for index, (k, v) in enumerate(sorted(manifest.items())):
+            outfile.write(f'"{k}": {json.dumps(v)}')
+
+            # Can't have a trailing comma on last dictionary entry in JSON
+            if index < len(manifest) - 1:
+                outfile.write(",")
+
+            outfile.write("\n")
+        outfile.write("}")
+
+
+def create_report_file(args, summary_table):
+    """
+    Writes a detailed report for the last transfer in JSON format to disk.
+
+    Parameters
+    ----------
+    args : argparse.Namespace
+        The parsed command-line arguments, including the path to write the
+        summary report to. A listing of all provided arguments is included in
+        the report file.
+    summary_table : dict
+        Dictionary containg the summarized results of DUM ingress reqeust to
+        write to disk.
+
+    """
+    logger = get_logger("create_report_file")
+
+    uploaded = list(sorted(chain(*summary_table["uploaded"].values())))
+    skipped = list(sorted(chain(*summary_table["skipped"].values())))
+    failed = list(sorted(chain(*summary_table["failed"].values())))
+
+    report = {
+        "Arguments": str(args),
+        "Batch Size": summary_table["batch_size"],
+        "Total Batches": summary_table["num_batches"],
+        "Start Time": str(datetime.fromtimestamp(summary_table["start_time"], tz=timezone.utc)),
+        "Finish Time": str(datetime.fromtimestamp(summary_table["end_time"], tz=timezone.utc)),
+        "Uploaded": uploaded,
+        "Total Uploaded": len(uploaded),
+        "Skipped": skipped,
+        "Total Skipped": len(skipped),
+        "Failed": failed,
+        "Total Failed": len(failed),
+        "Bytes Transferred": summary_table["transferred"],
+    }
+
+    report["Total Files"] = report["Total Uploaded"] + report["Total Skipped"] + report["Total Failed"]
+
+    try:
+        logger.info("Writing JSON summary report to %s", args.report_path)
+
+        with open(args.report_path, "w") as outfile:
+            json.dump(report, outfile, indent=4)
+    except OSError as err:
+        logger.warning("Failed to write summary report to %s, reason: %s", args.report_path, str(err))

--- a/tests/pds/ingress/util/test_report_util.py
+++ b/tests/pds/ingress/util/test_report_util.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+import json
+import os
+import tempfile
+import unittest
+from argparse import Namespace
+from datetime import datetime
+from datetime import timezone
+from os.path import abspath
+from os.path import exists
+from os.path import join
+
+from pds.ingress.util.report_util import create_report_file
+from pds.ingress.util.report_util import initialize_summary_table
+from pds.ingress.util.report_util import read_manifest_file
+from pds.ingress.util.report_util import write_manifest_file
+from pkg_resources import resource_filename
+
+
+class ReportUtilTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        """Set up directories and files for testing"""
+        cls.starting_dir = abspath(os.curdir)
+        cls.test_dir = resource_filename(__name__, "")
+
+        os.chdir(cls.test_dir)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        """At completion re-establish starting directory"""
+        os.chdir(cls.starting_dir)
+
+    def setUp(self) -> None:
+        """Create a temporary directory that each test can populate as necessary"""
+        self.working_dir = tempfile.TemporaryDirectory(prefix="test_report_util_", suffix="_temp", dir=os.curdir)
+
+    def tearDown(self) -> None:
+        """Return to starting directory and delete temp dir"""
+        os.chdir(self.test_dir)
+        self.working_dir.cleanup()
+
+    def test_manifest_file_read_write(self):
+        """Test the read/write functions for manifest file creation"""
+        dummy_manifest = {
+            "path/to/sample/file.txt": {
+                "ingress_path": "/absoulte/path/to/sample/file.txt",
+                "md5": "deadbeefdeadbeefdeadbeefdeadbeef",
+                "size": 1234,
+                "last_modified": "2024-06-09T08:57:23+00:00",
+            }
+        }
+
+        manifest_path = join(self.working_dir.name, "dummy_manifest.json")
+
+        write_manifest_file(dummy_manifest, manifest_path)
+
+        self.assertTrue(exists(manifest_path))
+
+        read_manifest = read_manifest_file(manifest_path)
+
+        self.assertDictEqual(dummy_manifest, read_manifest)
+
+        # Create a manifest that does not conform to the expected format
+        # Upon re-reading, we should detect this and return an empty manifest
+        dummy_manifest = {
+            "path/to/sample/file.txt": {
+                "ingress_path": "/absoulte/path/to/sample/file.txt",
+                "md5": "deadbeefdeadbeefdeadbeefdeadbeef",
+                "size": 1234,
+            }
+        }
+
+        write_manifest_file(dummy_manifest, manifest_path)
+
+        self.assertTrue(exists(manifest_path))
+
+        with self.assertLogs(level="WARNING") as cm:
+            read_manifest = read_manifest_file(manifest_path)
+            self.assertEqual(
+                cm.output[-1], "WARNING:read_manifest_path:A new manifest will be generated for this execution."
+            )
+
+        self.assertTrue(len(read_manifest) == 0)
+
+    def test_report_file_creation(self):
+        """Test creation of the summary report file"""
+        summary_table = initialize_summary_table()
+
+        summary_table["uploaded"][0].add("path/to/uploaded.txt")
+        summary_table["skipped"][0].add("path/to/skipped.txt")
+        summary_table["failed"][0].add("path/to/failed.txt")
+        summary_table["transferred"] = 100
+        summary_table["end_time"] = summary_table["start_time"]
+        summary_table["batch_size"] = 10
+        summary_table["num_batches"] = 2
+
+        expected_report_path = join(self.working_dir.name, "dum_report.json")
+
+        args = Namespace(
+            config_path="config/mcp.test.ingress.config.ini",
+            node="sbn",
+            prefix="/absolute/",
+            force_overwrite=True,
+            num_threads=4,
+            log_path="dum_log.txt",
+            manifest_path="dum_manifest.json",
+            report_path=expected_report_path,
+            dry_run=False,
+            log_level="info",
+            ingress_paths=["/absolute/path/to"],
+        )
+
+        create_report_file(args, summary_table)
+
+        self.assertTrue(exists(expected_report_path))
+
+        with open(expected_report_path) as infile:
+            read_summary = json.load(infile)
+
+        self.assertIn("Arguments", read_summary)
+        self.assertEqual(read_summary["Arguments"], str(args))
+
+        self.assertIn("Batch Size", read_summary)
+        self.assertEqual(read_summary["Batch Size"], 10)
+
+        self.assertIn("Total Batches", read_summary)
+        self.assertEqual(read_summary["Total Batches"], 2)
+
+        self.assertIn("Start Time", read_summary)
+        self.assertEqual(
+            read_summary["Start Time"], str(datetime.fromtimestamp(summary_table["start_time"], tz=timezone.utc))
+        )
+
+        self.assertIn("Finish Time", read_summary)
+        self.assertEqual(
+            read_summary["Finish Time"], str(datetime.fromtimestamp(summary_table["end_time"], tz=timezone.utc))
+        )
+
+        self.assertIn("Uploaded", read_summary)
+        self.assertIsInstance(read_summary["Uploaded"], list)
+        self.assertEqual(len(read_summary["Uploaded"]), 1)
+        self.assertEqual(read_summary["Uploaded"][0], "path/to/uploaded.txt")
+
+        self.assertIn("Total Uploaded", read_summary)
+        self.assertEqual(read_summary["Total Uploaded"], 1)
+
+        self.assertIn("Skipped", read_summary)
+        self.assertIsInstance(read_summary["Skipped"], list)
+        self.assertEqual(len(read_summary["Skipped"]), 1)
+        self.assertEqual(read_summary["Skipped"][0], "path/to/skipped.txt")
+
+        self.assertIn("Total Skipped", read_summary)
+        self.assertEqual(read_summary["Total Skipped"], 1)
+
+        self.assertIn("Failed", read_summary)
+        self.assertIsInstance(read_summary["Failed"], list)
+        self.assertEqual(len(read_summary["Failed"]), 1)
+        self.assertEqual(read_summary["Failed"][0], "path/to/failed.txt")
+
+        self.assertIn("Total Failed", read_summary)
+        self.assertEqual(read_summary["Total Failed"], 1)
+
+        self.assertIn("Bytes Transferred", read_summary)
+        self.assertEqual(read_summary["Bytes Transferred"], 100)
+
+        self.assertIn("Total Files", read_summary)
+        self.assertEqual(read_summary["Total Files"], 3)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->

## 🗒️ Summary
This branch adds support for the DUM client script to re-ingest an existing Manifest file so that its contents can be reused for a subsequent request, rather than recomputing each time. This should help to save time during a discipline node's workflow whenever a transfer request needs to be restarted or resumed.

Additional changes:

- The branch also does some refactoring of report-related functions to a new module, `report_util.py`, and adds a unit test suite for said module.
- Small tweaks made to certain progress bars to make them more intuitive to read.
- A new log filter has been added to prevent the identical messages from being written multiple times.
- Documentation has been updated to describe new features of the client added since the previous release.

## ⚙️ Test Data and/or Report
New unit test suite has been added to test creation of Manifest and Report files.
Branch is passing CI system:
```
py39: commands[0]> pytest
============================= test session starts ==============================
platform linux -- Python 3.9.21, pytest-8.3.4, pluggy-1.5.0
cachedir: .tox/py39/.pytest_cache
rootdir: /home/runner/work/data-upload-manager/data-upload-manager
configfile: pyproject.toml
plugins: xdist-3.3.1, cov-6.0.0
collected 17 items

tests/pds/ingress/service/test_pds_ingress_app.py ......                 [ 35%]
tests/pds/ingress/util/test_auth_util.py ..                              [ 47%]
tests/pds/ingress/util/test_config_util.py ..                            [ 58%]
tests/pds/ingress/util/test_log_util.py ...                              [ 76%]
tests/pds/ingress/util/test_path_util.py ..                              [ 88%]
tests/pds/ingress/util/test_report_util.py ..                            [100%]

=============================== warnings summary ===============================
```
And
```
Trim Trailing Whitespace.................................................Passed
Fix End of Files.........................................................Passed
Check that executables have shebangs.....................................Passed
Check for merge conflicts................................................Passed
Debug Statements (Python)................................................Passed
Check Yaml...............................................................Passed
Reorder python imports...................................................Passed
black....................................................................Passed
flake8...................................................................Passed
Detect secrets...........................................................Passed
  py39: OK (54.41=setup[34.75]+cmd[19.66] seconds)
  docs: OK (33.19=setup[32.28]+cmd[0.90] seconds)
  lint: OK (14.34=setup[1.93]+cmd[12.41] seconds)
  congratulations :) (102.06 seconds)
```

## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->
Resolves #122 

