### PR TITLE
Status Service Manifest File Staging

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -160,7 +160,7 @@
         "filename": "src/pds/ingress/conf.default.ini",
         "hashed_secret": "8bddbd992daa34fbedf86364802cf5a6ad01fd20",
         "is_verified": false,
-        "line_number": 12
+        "line_number": 11
       }
     ],
     "tests/pds/ingress/util/test_auth_util.py": [
@@ -180,5 +180,5 @@
       }
     ]
   },
-  "generated_at": "2025-04-29T20:08:10Z"
+  "generated_at": "2025-06-25T16:29:45Z"
 }

--- a/src/pds/ingress/client/pds_ingress_client.py
+++ b/src/pds/ingress/client/pds_ingress_client.py
@@ -396,7 +396,7 @@ def request_batch_for_ingress(request_batch, batch_index, node_id, force_overwri
     api_gateway_id = api_gateway_config["id"]
     api_gateway_region = api_gateway_config["region"]
     api_gateway_stage = api_gateway_config["stage"]
-    api_gateway_resource = api_gateway_config["resource"]
+    api_gateway_resource = "request"
 
     api_gateway_url = api_gateway_template.format(
         id=api_gateway_id, region=api_gateway_region, stage=api_gateway_stage, resource=api_gateway_resource

--- a/src/pds/ingress/client/pds_status_client.py
+++ b/src/pds/ingress/client/pds_status_client.py
@@ -15,6 +15,7 @@ import requests
 from pds.ingress import __version__
 from pds.ingress.util.auth_util import AuthUtil
 from pds.ingress.util.config_util import ConfigUtil
+from pds.ingress.util.hash_util import md5_for_path
 from pds.ingress.util.log_util import get_log_level
 from pds.ingress.util.log_util import get_logger
 from pds.ingress.util.node_util import NodeUtil
@@ -107,14 +108,6 @@ def main(args):
     if not os.path.exists(args.manifest_path):
         raise ValueError(f'Manifest path "{args.manifest_path}" does not exist')
 
-    logger.info(f"Reading Manifest file {args.manifest_path}")
-    with open(os.path.abspath(args.manifest_path), "r") as infile:
-        manifest = json.load(infile)
-
-    # Trim fields that are not needed by the status service
-    for key in manifest:
-        manifest[key].pop("ingress_path")
-
     cognito_config = config["COGNITO"]
 
     if not cognito_config["username"] and cognito_config["password"]:
@@ -129,13 +122,65 @@ def main(args):
     api_gateway_id = api_gateway_config["id"]
     api_gateway_region = api_gateway_config["region"]
     api_gateway_stage = api_gateway_config["stage"]
+
+    # Submit the request to stage the manifest file to S3
+    request = [
+        {
+            "ingress_path": args.manifest_path,
+            "trimmed_path": os.path.join("manifests", os.path.basename(args.manifest_path)),
+            "md5": md5_for_path(args.manifest_path).hexdigest(),
+            "size": os.stat(args.manifest_path).st_size,
+            "last_modified": os.path.getmtime(args.manifest_path),
+        }
+    ]
+
+    api_gateway_resource = "request"
+
+    api_gateway_url = api_gateway_template.format(
+        id=api_gateway_id, region=api_gateway_region, stage=api_gateway_stage, resource=api_gateway_resource
+    )
+
+    params = {"node": args.node, "node_name": NodeUtil.node_id_to_long_name[args.node]}
+    headers = {
+        "Authorization": bearer_token,
+        "UserGroup": NodeUtil.node_id_to_group_name(args.node),
+        "ForceOverwrite": "1",  # Likely we'll repeat requests using same manifest file names, so always overwrite
+        "ClientVersion": __version__,
+        "content-type": "application/json",
+        "x-amz-docs-region": api_gateway_region,
+    }
+
+    logger.info("Submitting S3 upload request for Manifest file...")
+    response = requests.post(api_gateway_url, params=params, data=json.dumps(request), headers=headers, timeout=600)
+
+    if response.status_code == HTTPStatus.OK:
+        ingress_response = response.json()[0]  # Should only ever be one item in the response
+    else:
+        response.raise_for_status()
+
+    bucket = ingress_response.get("bucket")
+    key = ingress_response.get("key")
+    s3_ingress_url = ingress_response.get("s3_url")
+
+    if any(value is None for value in [bucket, key, s3_ingress_url]):
+        raise RuntimeError("Invalid response from S3 ingress request, missing bucket, key, or s3_url")
+
+    headers = {"Content-MD5": ingress_response.get("base64_md5")}
+
+    logger.info("Uploading Manifest file to S3...")
+    with open(os.path.abspath(args.manifest_path), "r") as infile:
+        response = requests.put(s3_ingress_url, data=infile, headers=headers)
+        response.raise_for_status()
+
+    # Submit the request to the status service, informing it of the S3 location of the manifest file
     api_gateway_resource = "status"
 
     api_gateway_url = api_gateway_template.format(
         id=api_gateway_id, region=api_gateway_region, stage=api_gateway_stage, resource=api_gateway_resource
     )
 
-    payload = {"Message": manifest, "Email": args.email, "Node": args.node}
+    manifest_s3_location = f"s3://{bucket}/{key}"
+    payload = {"Message": manifest_s3_location, "Email": args.email, "Node": args.node}
 
     headers = {
         "Authorization": bearer_token,
@@ -145,11 +190,11 @@ def main(args):
         "x-amz-docs-region": api_gateway_region,
     }
 
-    logger.info("Submitting manifest to Status Service...")
+    logger.info("Submitting request to Status Service...")
     response = requests.post(api_gateway_url, data=json.dumps(payload), headers=headers, timeout=600)
 
     if response.status_code == HTTPStatus.OK:
-        logger.info("Status request successfully submitted.")
+        logger.info("Status request successfully submitted, report will be emailed to %s", args.email)
     else:
         response.raise_for_status()
 

--- a/src/pds/ingress/client/pds_status_client.py
+++ b/src/pds/ingress/client/pds_status_client.py
@@ -129,7 +129,7 @@ def main(args):
     api_gateway_id = api_gateway_config["id"]
     api_gateway_region = api_gateway_config["region"]
     api_gateway_stage = api_gateway_config["stage"]
-    api_gateway_resource = "status"  # TODO this doesn't need to be defined by INI config
+    api_gateway_resource = "status"
 
     api_gateway_url = api_gateway_template.format(
         id=api_gateway_id, region=api_gateway_region, stage=api_gateway_stage, resource=api_gateway_resource

--- a/src/pds/ingress/conf.default.ini
+++ b/src/pds/ingress/conf.default.ini
@@ -4,7 +4,6 @@ url_template = https://{id}.execute-api.{region}.amazonaws.com/{stage}/{resource
 id           = abcdefghi
 region       = us-west-2
 stage        = test
-resource     = request
 
 [COGNITO]
 client_id    = 123456789

--- a/src/pds/ingress/service/pds_ingress_app.py
+++ b/src/pds/ingress/service/pds_ingress_app.py
@@ -457,6 +457,8 @@ def lambda_handler(event, context):
                     "result": HTTPStatus.NOT_FOUND,
                     "trimmed_path": trimmed_path,
                     "s3_url": None,
+                    "bucket": None,
+                    "key": None,
                     "message": f"Mapped bucket {destination_bucket} does not exist or has insufficient access permisisons",
                 }
             )
@@ -485,6 +487,8 @@ def lambda_handler(event, context):
                             "trimmed_path": trimmed_path,
                             "ingress_path": ingress_path,
                             "s3_urls": signed_urls,
+                            "bucket": destination_bucket,
+                            "key": object_key,
                             "upload_complete_url": complete_url,
                             "upload_abort_url": abort_url,
                             "num_parts": num_parts,
@@ -511,6 +515,8 @@ def lambda_handler(event, context):
                             "md5": md5_digest,
                             "base64_md5": base64_md5_digest,
                             "s3_url": s3_url,
+                            "bucket": destination_bucket,
+                            "key": object_key,
                             "message": "Request success",
                         }
                     )
@@ -524,6 +530,8 @@ def lambda_handler(event, context):
                         "result": HTTPStatus.NO_CONTENT,
                         "trimmed_path": trimmed_path,
                         "s3_url": None,
+                        "bucket": destination_bucket,
+                        "key": object_key,
                         "message": "File already exists",
                     }
                 )

--- a/src/pds/ingress/util/config_util.py
+++ b/src/pds/ingress/util/config_util.py
@@ -244,9 +244,9 @@ def bucket_for_path(node_bucket_map, file_path, logger):
     for path in node_bucket_map.get("paths", []):
         if _match_path_to_prefix(file_path, path["prefix"]):
             bucket = path["bucket"]
-            logger.info("Resolved bucket location %s for path %s", bucket, file_path)
+            logger.debug("Resolved bucket location %s for path %s", bucket, file_path)
             break
     else:
-        logger.warning('No bucket location configured for path "%s", using default bucket %s', file_path, bucket)
+        logger.debug('No bucket location configured for path "%s", using default bucket %s', file_path, bucket)
 
     return bucket

--- a/tests/pds/ingress/service/test_pds_ingress_app.py
+++ b/tests/pds/ingress/service/test_pds_ingress_app.py
@@ -123,14 +123,26 @@ class PDSIngressAppTest(unittest.TestCase):
             body[0]["ingress_path"], "/home/user/data/gbo.ast.catalina.survey/bundle_gbo.ast.catalina.survey_v1.0.xml"
         )
 
-        self.assertIn("message", body[0])
-        self.assertEqual(body[0]["message"], "Request success")
+        self.assertIn("md5", body[0])
+        self.assertEqual(body[0]["md5"], "deadbeefdeadbeefdeadbeef")
+
+        self.assertIn("base64_md5", body[0])
+        self.assertEqual(body[0]["base64_md5"], "3q2+796tvu/erb7v")
 
         self.assertIn("s3_url", body[0])
         s3_url = body[0]["s3_url"]
 
         expected_url = "https://pds-sbn-staging-test.s3.amazonaws.com/sbn/gbo.ast.catalina.survey/bundle_gbo.ast.catalina.survey_v1.0.xml"
         self.assertTrue(s3_url.startswith(expected_url))
+
+        self.assertIn("bucket", body[0])
+        self.assertEqual(body[0]["bucket"], "pds-sbn-staging-test")
+
+        self.assertIn("key", body[0])
+        self.assertEqual(body[0]["key"], "sbn/gbo.ast.catalina.survey/bundle_gbo.ast.catalina.survey_v1.0.xml")
+
+        self.assertIn("message", body[0])
+        self.assertEqual(body[0]["message"], "Request success")
 
         test_event = {
             "body": json.dumps(

--- a/tests/pds/ingress/util/test_config_util.py
+++ b/tests/pds/ingress/util/test_config_util.py
@@ -104,7 +104,6 @@ class ConfigUtilTest(unittest.TestCase):
         self.assertEqual(parser["API_GATEWAY"]["id"], "abcdefghi")
         self.assertEqual(parser["API_GATEWAY"]["region"], "us-west-2")
         self.assertEqual(parser["API_GATEWAY"]["stage"], "test")
-        self.assertEqual(parser["API_GATEWAY"]["resource"], "request")
 
         self.assertEqual(parser["COGNITO"]["client_id"], "123456789")
         self.assertEqual(parser["COGNITO"]["username"], "cognito_user")


### PR DESCRIPTION
<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->

## 🗒️ Summary
This PR updates the DUM Status Service client and service to stage a user-provided Manifest file in S3, rather than send the contents of the file directly in an SQS message. This is a small step towards supporting large manifest files submitted to the status service in production.

## ⚙️ Test Data and/or Report
[Unit tests](https://github.com/NASA-PDS/data-upload-manager/actions/runs/16301012344/job/46035337830#step:5:452) for the status and ingress services have been updated to account for changes made by this branch.
This branch has also been deployed and tested in PDS CDS Test.

## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->
Partially resolves #224 


