### PR TITLE
Include and Exclude filtering options for input file set

### DIFF
--- a/src/pds/ingress/client/pds_ingress_client.py
+++ b/src/pds/ingress/client/pds_ingress_client.py
@@ -686,6 +686,36 @@ def setup_argparser():
         "overwrite any existing versions of files within the PDS Cloud.",
     )
     parser.add_argument(
+        "--include",
+        "-i",
+        type=str,
+        action="append",
+        default=list(),
+        dest="includes",
+        metavar="PATTERN",
+        help="Specify a file path pattern to match against when determining "
+        "which files should be included with an Ingress request. "
+        "Unix-style wildcard patterns are supported. "
+        "Include patterns are always applied prior to any Exclude patterns. "
+        "This argument can be specified multiple times to configure multiple "
+        "include patterns. Include patterns are evaluated in the order they provided.",
+    )
+    parser.add_argument(
+        "--exclude",
+        "-e",
+        type=str,
+        action="append",
+        default=list(),
+        dest="excludes",
+        metavar="PATTERN",
+        help="Specify a file path pattern to match against when determining "
+        "which files should be excluded from an Ingress request. "
+        "Unix-style wildcard patterns are supported. "
+        "Exclude patterns are always applied after any Include patterns. "
+        "This argument can be specified multiple times to configure multiple "
+        "exclude patterns. Exclude patterns are evaluated in the order they provided.",
+    )
+    parser.add_argument(
         "--num-threads",
         "-t",
         type=int,
@@ -795,7 +825,7 @@ def main(args):
     # by the user
     logger.info("Determining paths for ingress...")
     with get_path_progress_bar(args.ingress_paths) as pbar:
-        resolved_ingress_paths = PathUtil.resolve_ingress_paths(args.ingress_paths, pbar)
+        resolved_ingress_paths = PathUtil.resolve_ingress_paths(args.ingress_paths, args.includes, args.excludes, pbar)
 
     # Initialize the summary table, and populate the "unprocessed" table the set
     # of resolved ingress paths


### PR DESCRIPTION

<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->

## 🗒️ Summary
This branch adds `--include` and `--exclude` command line options to allow users of the DUM client script to filter the set of resolved ingress paths prior to submission to the service.

The arguments can be used independently or together to derive the filtered list of paths. Unix style wildcards can also be used with each provided pattern.

## ⚙️ Test Data and/or Report
A new unit test has been added to test the use of include and exclude filters when deriving a set of input paths.
This branch has also been deployed and tested on PDS CDS Dev using filters against sample CSS data paths.

## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->
Resolves #262 


