### PR TITLE
Python 3.13 upgrade

### DIFF
--- a/.github/workflows/branch_cicd.yaml
+++ b/.github/workflows/branch_cicd.yaml
@@ -42,7 +42,7 @@ jobs:
                 name: Set up Python 3
                 uses: actions/setup-python@v5
                 with:
-                    python-version: '3.9'
+                    python-version: '3.13'
             -
                 name: 💵 Python Cache
                 uses: actions/cache@v4

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The PDS Data Upload Manager provides the client application and server interface
 
 The PDS Data Delivery Manager has the following prerequisties:
 
-- `python3` for running the client application and unit tests
+- `python3` for running the client application and unit tests (Python 3.13 or later)
 - `terraform` for creating and deploying DUM server components to AWS
 
 ## User Quickstart
@@ -127,8 +127,7 @@ Configure the `pre-commit` hooks:
 To isolate and be able to re-produce the environment for this package, you should use a [Python Virtual Environment](https://docs.python.org/3/tutorial/venv.html). To do so, run:
 
     python -m venv venv
-
-Then exclusively use `venv/bin/python`, `venv/bin/pip`, etc. (It is no longer recommended to use `venv/bin/activate`.)
+    source bin/venv/activate  # Substitute with `source bin/venv/activate.csh` for csh/tcsh users
 
 If you have `tox` installed and would like it to create your environment and install dependencies for you run:
 
@@ -160,7 +159,7 @@ Our unit tests are launched with the command:
 
 You can build this projects' docs with:
 
-    sphinx-build docs/source docs/build
+    sphinx-build -b html docs/source docs/build
 
 You can access the build files in the following directory relative to the project root:
 

--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -1,10 +1,10 @@
-️Command Line API
-=================
+Command Line API
+================
 
 This section contains details on the interfaces for the command line tools.
 
 pds-ingress-client
------------
+------------------
 
 .. argparse::
    :module: pds.ingress.client.pds_ingress_client

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -34,11 +34,8 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinx.ext.githubpages',
     'sphinx.ext.autosummary',
-    'sphinx_rtd_theme'
+    'sphinxarg.ext'
 ]
-
-# Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -77,7 +74,6 @@ html_css_files = [
 html_theme_options = {
     'canonical_url': '',
     'logo_only': False,
-    'display_version': True,
     'prev_next_buttons_location': 'bottom',
     'style_external_links': False,
     # Toc options

--- a/docs/source/development/index.rst
+++ b/docs/source/development/index.rst
@@ -9,7 +9,7 @@ To obtain a copy of the code and work on a new branch::
     git clone https://github.com/NASA-PDS/data-upload-manager.git
     git checkout -b "<issue number>_<issue name>"
 
-Create a virtual environment in ``venv`` using Python 3.9 or later::
+Create a virtual environment in ``venv`` using Python 3.13 or later::
 
     python3 -m venv venv
 
@@ -31,7 +31,7 @@ The code base includes unit tests. Once you've installed the service, you can
 run the unit tests with the following command (assuming the virtual environment
 has been activated, see above)::
 
-    tox py39
+    tox -e py313
 
 
 Making Releases

--- a/docs/source/installation/index.rst
+++ b/docs/source/installation/index.rst
@@ -9,7 +9,7 @@ Requirements
 Prior to installing this software, ensure your system meets the following
 requirements:
 
-* Python_ 3.9 or above. Python 2 is *not* supported.
+* Python_ 3.13 or above. Python 2 is *not* supported.
 * Terraform 1.0.11 or above. Note that Terraform is only required when deploying
   the server side components. It is not required to run the client-side script.
   For more information on deploying the server side components via Terraform,

--- a/docs/source/terraform/index.rst
+++ b/docs/source/terraform/index.rst
@@ -1,5 +1,5 @@
- 🌎  Terraform
-==================
+🌎  Terraform
+=============
 
 This section describes how to deploy the server side components of the DUM to
 AWS via Terraform_. These instructions are intended for PDS Engineering Node

--- a/docs/source/usage/index.rst
+++ b/docs/source/usage/index.rst
@@ -27,7 +27,7 @@ Specifying the node ID of the requestor is accomplished via the ``--node`` argum
 specifying one of the following node name values: ``atm,eng,geo,img,naif,ppi,rs,rms,sbn``
 
 The ``--dry-run`` flag can be used to have ``pds-ingress-client`` determine the
-full set of files and directories to  be processed without actually submitting
+full set of files and directories to be processed without actually submitting
 anything for ingest to PDS Cloud. This feature can be useful to ensure the correct
 set of files are being included for a request before performing any communication
 with the Server side of DUM.

--- a/integration/pds/ingress/dum_integration_tests.py
+++ b/integration/pds/ingress/dum_integration_tests.py
@@ -7,8 +7,7 @@ import tempfile
 import unittest
 from datetime import datetime, timezone
 from os.path import abspath, basename, dirname, exists, join
-
-from pkg_resources import resource_filename
+from importlib import resources
 
 from pds.ingress import __version__
 from pds.ingress.util.hash_util import md5_for_path
@@ -23,7 +22,7 @@ class DumIntegrationTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.test_dir = resource_filename(__name__, "")
+        cls.test_dir = str(resources.files(__name__).parent)
         cls.scripts_dir = abspath(join(cls.test_dir, os.pardir, os.pardir, 'scripts'))
         cls.config_dir = abspath(join(cls.test_dir, os.pardir, os.pardir, 'config'))
         cls.terraform_dir = abspath(join(cls.test_dir, os.pardir, os.pardir, os.pardir, 'terraform'))

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,8 +15,6 @@ url = https://github.com/NASA-PDS/data-upload-manager
 download_url = https://github.com/NASA-PDS/data-upload-manager/releases/
 classifiers =
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.9
-    License :: OSI Approved :: Apache Software License
     Operating System :: OS Independent
 
 
@@ -51,7 +49,7 @@ include_package_data = True
 package_dir =
     = src
 packages = find_namespace:
-python_requires = >= 3.9
+python_requires = >= 3.13
 
 [options.entry_points]
 console_scripts =
@@ -78,6 +76,7 @@ dev =
     pre-commit>=3.3.3,<4.4.0
     sphinx>=7.2.6,<8.3.0
     sphinx-rtd-theme>=2.0,<3.1
+    sphinx-argparse~=0.5.2
     terraform-local>=0.18.2,<0.25.0
     tox>=4.11,<4.29
     types-setuptools>=68.1.0,<80.9.1

--- a/terraform/modules/lambda/service/ingress_service.tf
+++ b/terraform/modules/lambda/service/ingress_service.tf
@@ -143,14 +143,14 @@ resource "aws_lambda_layer_version" "lambda_ingress_service_pyyaml_layer" {
   s3_bucket           = module.lambda_bucket.bucket_id
   s3_key              = "layer-PyYAML.zip"
   layer_name          = "PyYAML"
-  compatible_runtimes = ["python3.9","python3.10","python3.11","python3.12"]
+  compatible_runtimes = ["python3.9","python3.10","python3.11","python3.12","python3.13"]
 }
 
 resource "aws_lambda_layer_version" "lambda_ingress_service_yamale_layer" {
   s3_bucket           = module.lambda_bucket.bucket_id
   s3_key              = "layer-Yamale.zip"
   layer_name          = "Yamale"
-  compatible_runtimes = ["python3.9","python3.10","python3.11","python3.12"]
+  compatible_runtimes = ["python3.9","python3.10","python3.11","python3.12","python3.13]
 }
 
 # Create the Ingress Lambda functions using the zips uploaded to S3
@@ -161,7 +161,7 @@ resource "aws_lambda_function" "lambda_ingress_service" {
   s3_bucket = module.lambda_bucket.bucket_id
   s3_key    = module.lambda_ingress_service_s3_object.s3_object_key
 
-  runtime = "python3.10"
+  runtime = "python3.13"
   handler = "pds_ingress_app.lambda_handler"
 
   source_code_hash = data.archive_file.lambda_ingress_service.output_base64sha256
@@ -195,7 +195,7 @@ resource "aws_lambda_function" "lambda_status_service" {
   s3_bucket = module.lambda_bucket.bucket_id
   s3_key    = module.lambda_status_service_s3_object.s3_object_key
 
-  runtime = "python3.10"
+  runtime = "python3.13"
   handler = "pds_status_app.lambda_handler"
 
   source_code_hash = data.archive_file.lambda_status_service.output_base64sha256

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py39, docs, lint
+envlist = py313, docs, lint
 isolated_build = True
 
 [testenv]
@@ -10,7 +10,7 @@ commands = pytest
 [testenv:docs]
 deps = .[dev]
 whitelist_externals = python
-commands = sphinx-build docs/source docs/build
+commands = sphinx-build -b html docs/source docs/build
 
 [testenv:lint]
 deps = pre-commit
@@ -19,6 +19,6 @@ commands=
 skip_install = true
 
 [testenv:dev]
-basepython = python3.9
+basepython = python3.13
 usedevelop = True
 deps = .[dev]


### PR DESCRIPTION
## 🗒️ Summary

Merge this to upgrade the package to support Python 3.13.

- Branch CI/CD workflow using 3.13
- Update README.md to reflect Python 3.13 and Sphinx build instructions
- Fixes for reStructuredText title formatting, updates for 3.13
- Adding Sphinx argparse extension, modernizing Sphinx `conf.py` settings
- Replacing `pkg_resources` with `importlib.resources`
- Setuptools metadata updates for Python 3.13
- Terraform runtimes to include (and to use) Python 3.13
- Tox updates for 3.13

## ⚙️ Test Data and/or Report

```console
$ tox -e py313
…
============================================ 28 passed in 360.58s (0:06:00) ============================================
py313: OK ✔ in 6 minutes 17.82 seconds
…
The HTML pages are in docs/build.
docs: OK ✔ in 16.59 seconds
…
Trim Trailing Whitespace.................................................Passed
Fix End of Files.........................................................Passed
Check that executables have shebangs.....................................Passed
Check for merge conflicts................................................Passed
Debug Statements (Python)................................................Passed
Check Yaml...............................................................Passed
Reorder python imports...................................................Passed
black....................................................................Passed
flake8...................................................................Passed
Detect secrets...........................................................Passed
  py313: OK (377.82=setup[16.32]+cmd[361.50] seconds)
  docs: OK (16.59=setup[15.53]+cmd[1.05] seconds)
  lint: OK (3.99=setup[1.27]+cmd[2.72] seconds)
  congratulations :) (398.46 seconds)
```

@collinss-jpl will rely on you to ensure the command-line utilities and Terraform still works 😉

## ♻️ Related Issues

See https://github.com/NASA-PDS/template-repo-python/issues/105
