### PR TITLE
S3 Metadata Update Script Initial Addition

### DIFF
--- a/src/pds/ingress/service/config/bucket-map.yaml.tmpl
+++ b/src/pds/ingress/service/config/bucket-map.yaml.tmpl
@@ -36,3 +36,7 @@ MAP:
       default:
         bucket:
           name: pds-sbn-staging-${venue}
+      paths:
+        - prefix: manifests/*
+          bucket:
+            name: pds-sbn-manifests-${venue}

--- a/src/pds/ingress/service/sync_s3_metadata.py
+++ b/src/pds/ingress/service/sync_s3_metadata.py
@@ -1,0 +1,221 @@
+"""
+===================
+sync_s3_metadata.py
+===================
+
+Lambda function which updates existing objects in S3 with metdata typically
+added by the rclone utility.
+"""
+import base64
+import calendar
+import concurrent.futures
+import logging
+import os
+from datetime import datetime
+
+import boto3
+
+
+s3 = boto3.client("s3")
+paginator = s3.get_paginator("list_objects_v2")
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+
+def update_s3_object_metadata(metadata_dict):
+    """
+    Updates an S3 object's metadata dictionary to include fields added during
+    rclone uploads.
+
+    Parameters
+    ----------
+    metadata_dict : dict
+        Dictionary of existing metadata for an S3 object. Must include 'md5'
+        and 'last_modified' fields.
+
+    Returns
+    -------
+    updated_metadata : dict
+        Updated metadata dictionary including 'md5chksum' and 'mtime' fields.
+
+    """
+    md5_digest = metadata_dict["md5"]
+    last_modified = metadata_dict["last_modified"]
+
+    base64_md5_digest = base64.b64encode(bytes.fromhex(md5_digest)).decode()
+    epoch_last_modified = calendar.timegm(datetime.fromisoformat(last_modified).timetuple())
+
+    updated_metadata = metadata_dict.copy()
+    updated_metadata["md5chksum"] = base64_md5_digest
+    updated_metadata["mtime"] = str(epoch_last_modified)
+
+    return updated_metadata
+
+
+def process_s3_object(bucket_name, key):
+    """
+    Processes a single S3 object to see if it requires metadata updates.
+
+    Parameters
+    ----------
+    bucket_name : str
+        Name of the S3 bucket.
+    key : str
+        S3 object key.
+
+    Returns
+    -------
+    key : str
+        The S3 object key.
+    status : str
+        Status of the operation: 'updated', 'skipped', or 'failed'.
+
+    """
+    try:
+        head = s3.head_object(Bucket=bucket_name, Key=key)
+        metadata_dict = head.get("Metadata", {})
+
+        if metadata_dict and "md5chksum" in metadata_dict and "mtime" in metadata_dict:
+            logger.debug(f"Object {key} already has required metadata. Skipping.")
+            return key, "skipped"
+
+        try:
+            updated_metadata = update_s3_object_metadata(metadata_dict)
+        except KeyError as err:
+            logger.error(f"Missing expected metadata key for object {key}: {err}")
+            return key, "failed"
+
+        logger.debug(f"Updating object {key} with {updated_metadata['md5chksum']=}, {updated_metadata['mtime']=}")
+
+        s3.copy_object(
+            Bucket=bucket_name,
+            Key=key,
+            CopySource={"Bucket": bucket_name, "Key": key},
+            Metadata=updated_metadata,
+            MetadataDirective="REPLACE",
+        )
+        return key, "updated"
+    except Exception as err:
+        logger.error(f"Failed to update metadata for object {key}, reason: {err}")
+        return key, "failed"
+
+
+def update_s3_objects_metadata(context, bucket_name, prefix=None, timeout_buffer_ms=5000):
+    """
+    Recursively iterates over all objects in an S3 bucket and updates their
+    metadata to include fields added during rclone uploads, if not already present.
+
+    Parameters
+    ----------
+    context : object
+        Object containing details of the AWS context in which the Lambda was
+        invoked.
+    bucket_name : str
+        Name of the S3 bucket.
+    prefix : str, optional
+        S3 key path to start traversal from.
+    timeout_buffer_ms : int, optional
+        Buffer time in milliseconds to stop processing before Lambda timeout.
+
+    Returns
+    -------
+    updated : list
+        List of S3 object keys that were updated.
+    skipped : list
+        List of S3 object keys that were skipped because they already had the
+        required metadata.
+    failed : list
+        List of S3 object keys that failed to be updated due to errors.
+    unprocessed : list
+        List of S3 object keys that were not processed due to Lambda timeout.
+
+    """
+    pagination_params = {"Bucket": bucket_name}
+
+    if prefix:
+        pagination_params["Prefix"] = prefix
+
+    updated = []
+    skipped = []
+    failed = []
+    unprocessed = []
+
+    keys = []
+
+    for page in paginator.paginate(**pagination_params):
+        for obj in page.get("Contents", []):
+            keys.append(obj["Key"])
+            unprocessed.append(obj["Key"])
+
+    num_cores = max(os.cpu_count(), 1)
+
+    logger.info(f"Available CPU cores: {num_cores}")
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=num_cores) as executor:
+        futures = [executor.submit(process_s3_object, bucket_name, key) for key in keys]
+
+        for future in concurrent.futures.as_completed(futures):
+            # Check Lambda remaining time
+            if context.get_remaining_time_in_millis() < timeout_buffer_ms:
+                logger.warning("Approaching Lambda timeout, cancelling remaining tasks.")
+                for f in futures:
+                    f.cancel()
+                break
+
+            key, status = future.result()
+
+            if status == "updated":
+                updated.append(key)
+            elif status == "skipped":
+                skipped.append(key)
+            else:
+                failed.append(key)
+
+            unprocessed.remove(key)
+
+    return updated, skipped, failed, unprocessed
+
+
+def lambda_handler(event, context):
+    """
+    Entrypoint for this Lambda function. Derives the S3 bucket name and prefix
+    from the event, then iterates over all objects within the location to update
+    their metadata for compliance with rclone-uploaded objects.
+
+    Parameters
+    ----------
+    event : dict
+        Dictionary containing details of the event that triggered the Lambda.
+    context : object
+        Object containing details of the AWS context in which the Lambda was
+        invoked.
+
+    Returns
+    -------
+    response : dict
+        JSON-compliant dictionary containing the results of the request.
+
+    """
+    bucket_name = event["bucket_name"]
+    prefix = event.get("prefix", None)
+
+    updated, skipped, failed, unprocessed = update_s3_objects_metadata(context, bucket_name, prefix)
+
+    result = {
+        "statusCode": 200,
+        "body": {
+            "message": "S3 Object Metadata update complete",
+            "bucket_name": bucket_name,
+            "prefix": prefix,
+            "processed": len(updated) + len(skipped) + len(failed),
+            "unprocessed": len(unprocessed),
+            "updated": len(updated),
+            "skipped": len(skipped),
+            "failed": len(failed),
+        },
+    }
+
+    logger.info("S3 Object Metadata update result:\n%s", result)
+
+    return result

--- a/src/pds/ingress/util/report_util.py
+++ b/src/pds/ingress/util/report_util.py
@@ -8,16 +8,12 @@ to track status of a DUM upload request.
 
 """
 import json
-import multiprocessing
 import os
 import time
 from datetime import datetime
 from datetime import timezone
 
 from pds.ingress.util.log_util import get_logger
-
-REPORT_SEMAPHORE = multiprocessing.Semaphore(1)
-"""Semaphore used to control write access to Batch progress bars"""
 
 EXPECTED_MANIFEST_KEYS = ("ingress_path", "md5", "size", "last_modified")
 """The keys we expect to find assigned to each mapping within a read manifest"""
@@ -63,19 +59,18 @@ def update_summary_table(summary_table, key, paths):
     if not isinstance(paths, list):
         paths = [paths]
 
-    with REPORT_SEMAPHORE:
-        summary_table[key].update(paths)
+    summary_table[key].update(paths)
 
-        if key == "uploaded":
-            # Update total number of bytes transferrred for successful uploads
-            summary_table["transferred"] += sum(os.stat(path).st_size for path in paths)
+    if key == "uploaded":
+        # Update total number of bytes transferrred for successful uploads
+        summary_table["transferred"] += sum(os.stat(path).st_size for path in paths)
 
-            # If this file or files previous failed, remove from the failed set
-            summary_table["failed"] -= set(paths)
+        # If this file or files previous failed, remove from the failed set
+        summary_table["failed"] -= set(paths)
 
-        # Prune any now-visted paths from the unprocessed set
-        if key != "unprocessed":
-            summary_table["unprocessed"] -= set(paths)
+    # Prune any now-visted paths from the unprocessed set
+    if key != "unprocessed":
+        summary_table["unprocessed"] -= set(paths)
 
 
 def print_ingress_summary(summary_table):

--- a/terraform/modules/lambda/service/variables.tf
+++ b/terraform/modules/lambda/service/variables.tf
@@ -41,6 +41,12 @@ variable "lambda_status_service_function_name" {
   description = "Name to assign to the Lambda Status Service function"
 }
 
+variable "lambda_metadata_sync_service_function_name" {
+  type        = string
+  default     = "nucleus-dum-metadata-sync-service"
+  description = "Name to assign to the Lambda Metadata Sync Service function"
+}
+
 variable "lambda_ingress_service_function_description" {
   type        = string
   default     = "PDS Data Upload Manager Ingress Service function"
@@ -51,6 +57,12 @@ variable "lambda_status_service_function_description" {
   type        = string
   default     = "PDS Data Upload Mangager Status Service function"
   description = "Description for the Lambda Status Service function"
+}
+
+variable "lambda_metadata_sync_service_function_description" {
+  type        = string
+  default     = "PDS Data Upload Manager Metadata Sync Service function"
+  description = "Description for the Lambda Metadata Sync Service function"
 }
 
 variable "lambda_ingress_service_iam_role_arn" {


### PR DESCRIPTION
<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->

## 🗒️ Summary
This branch adds a new Lambda function to the DUM service which can iterate over objects in an S3 bucket (presumably uploaded originally by DUM) to add additional metadata fields for compliance with rclone-uploaded files.

Input to the function consists only of a bucket name, and an optional prefix key to further restrict the files iterated over by the function.

This function supports multi-threading, where the number of threads is pinned to the number of cores provided to the Lambda function. The current configuration utilizes 4G of memory, which results in 3 cores allocated to the Lambda.

The function is also aware of the timeout assigned to the Lambda, and will gracefully exit just prior to expiration of the timeout. This means that for buckets with many files, the function may need to be run several times in order to visit all files. Files that already have the rclone metadata fields will be skipped on subsequent executions.

Terraform for DUM has been updated to include deployment of the new Lambda function.

This branch also fixes an unrelated issue where use of an unnecessary semaphore caused performance degradation in the DUM client.

## ⚙️ Test Data and/or Report
[No changes to unit test suite in this branch.](https://github.com/NASA-PDS/data-upload-manager/actions/runs/17447614857/job/49545741008#step:5:359)
This branch has been deployed to PDS CDS Dev and tested against sample CSS data which is missing the rlcone-provided fields:

<img width="1443" height="183" alt="Screenshot 2025-09-03 at 3 30 20 PM" src="https://github.com/user-attachments/assets/e51a09c6-c910-4e42-aefa-0bc194ba7c06" />

## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->
Refs #264 

