### PR TITLE
Reverted basepython to python3.13 in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
-envlist = py312, docs, lint
+envlist = py313, docs, lint
 requires = tox>=4.6
 
 [testenv]
 description = run tests
-basepython = python3.12
+basepython = python3.13
 package = wheel
 extras = dev
 usedevelop = true


### PR DESCRIPTION
<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->

## 🗒️ Summary
This branch fixes an issue in tox.ini that is preventing the release pipeline from completing. Since roundup is using Python 3.13, the tox environment must be 3.13 as well.

## ⚙️ Test Data and/or Report
https://github.com/NASA-PDS/data-upload-manager/actions/runs/18289785939/job/52073903312#step:5:454

## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->
N/A

