### PR TITLE
Skip crawling of excluded directories during path resolution

### DIFF
--- a/docs/source/usage/index.rst
+++ b/docs/source/usage/index.rst
@@ -45,6 +45,11 @@ times to include or exclude multiple patterns. The ``--include`` argument is app
 first, followed by the ``--exclude`` argument. If no ``--include`` arguments are
 provided, all files are included by default.
 
+When an ``--exclude`` pattern matches a directory path, that entire directory tree
+is pruned during path resolution and is never traversed. Patterns that only match
+files deeper within a directory (e.g. ``/data/logs/*.tmp``) filter just the matching
+files and leave the rest of the directory intact.
+
 Specifying the node ID of the requestor is accomplished via the ``--node`` argument,
 specifying one of the following node name values: ``atm,eng,geo,img,naif,ppi,rs,rms,sbn``
 

--- a/src/pds/ingress/client/pds_ingress_client.py
+++ b/src/pds/ingress/client/pds_ingress_client.py
@@ -800,6 +800,7 @@ def setup_argparser():
         help="Specify a file path pattern to match against when determining "
         "which files should be excluded from an Ingress request. "
         "Unix-style wildcard patterns are supported. "
+        "Patterns that match a directory path exclude that entire directory tree. "
         "Exclude patterns are always applied after any Include patterns. "
         "This argument can be specified multiple times to configure multiple "
         "exclude patterns. Exclude patterns are evaluated in the order they provided.",
@@ -925,7 +926,9 @@ def main(args):
     follow_symlinks = not args.skip_symlinks
     if args.skip_symlinks:
         logger.info("Skipping symbolic links during path resolution")
-    with get_path_progress_bar(args.ingress_paths) as pbar:
+    with get_path_progress_bar(
+        args.ingress_paths, args.includes, args.excludes, follow_symlinks=follow_symlinks
+    ) as pbar:
         resolved_ingress_paths = PathUtil.resolve_ingress_paths(
             args.ingress_paths, args.includes, args.excludes, pbar, follow_symlinks=follow_symlinks
         )

--- a/src/pds/ingress/util/path_util.py
+++ b/src/pds/ingress/util/path_util.py
@@ -16,6 +16,32 @@ class PathUtil:
     """Provides methods for working with local file system paths."""
 
     @staticmethod
+    def count_resolvable_ingress_paths(user_paths, includes, excludes, follow_symlinks=True):
+        """
+        Counts the number of non-hidden files that would be evaluated for ingress
+        after applying directory-level exclude pruning and file filters.
+
+        Parameters
+        ----------
+        user_paths : list of str
+            The collection of user-requested paths to include with the ingress
+            request. Can be any combination of file and directory paths.
+        includes : list of str
+            List of patterns defining which files to include for ingress.
+        excludes : list of str
+            List of patterns defining which files to exclude from ingress.
+        follow_symlinks : bool, optional
+            Whether to follow symbolic links when walking directories.
+
+        Returns
+        -------
+        int
+            Count of files that should be evaluated for ingress.
+
+        """
+        return sum(1 for _ in PathUtil._iter_resolvable_ingress_paths(user_paths, includes, excludes, follow_symlinks))
+
+    @staticmethod
     def resolve_ingress_paths(user_paths, includes, excludes, pbar, resolved_paths=None, follow_symlinks=True):
         """
         Iterates over the list of user-provided paths to derive the final
@@ -53,46 +79,139 @@ class PathUtil:
         # Initialize the list of resolved paths if necessary
         resolved_paths = resolved_paths or list()
 
+        for ingress_path in PathUtil._iter_resolvable_ingress_paths(
+            user_paths, includes, excludes, follow_symlinks, logger
+        ):
+            resolved_paths.append(ingress_path)
+            pbar.update()
+
+        return resolved_paths
+
+    @staticmethod
+    def _iter_resolvable_ingress_paths(user_paths, includes, excludes, follow_symlinks=True, logger=None):
+        """
+        Yields file paths that should be evaluated for ingress.
+
+        Parameters
+        ----------
+        user_paths : list of str
+            The collection of user-requested paths to include with the ingress
+            request. Can be any combination of file and directory paths.
+        includes : list of str
+            List of patterns defining which files to include for ingress.
+        excludes : list of str
+            List of patterns defining which files to exclude from ingress.
+        follow_symlinks : bool, optional
+            Whether to follow symbolic links when walking directories.
+        logger : logging.Logger, optional
+            Logger to emit skip/filter details to.
+
+        Yields
+        ------
+        str
+            Absolute file path accepted by the include/exclude filters.
+
+        """
         for user_path in user_paths:
             abs_user_path = os.path.abspath(user_path)
 
             if not os.path.exists(abs_user_path):
-                pbar.update()
-                logger.warning("Encountered path (%s) that does not actually exist, skipping...", abs_user_path)
+                if logger:
+                    logger.warning("Encountered path (%s) that does not actually exist, skipping...", abs_user_path)
                 continue
 
             if os.path.isfile(abs_user_path):
-                pbar.update()
-
-                # Skip symlinked files if follow_symlinks is False
                 if not follow_symlinks and os.path.islink(abs_user_path):
-                    logger.debug("Skipping symlinked file %s", abs_user_path)
+                    if logger:
+                        logger.debug("Skipping symlinked file %s", abs_user_path)
                     continue
 
                 if PathUtil.filter_file(abs_user_path, includes, excludes):
-                    logger.debug("Filtering path %s based on include/exclude filters", abs_user_path)
+                    if logger:
+                        logger.debug("Filtering path %s based on include/exclude filters", abs_user_path)
                     continue
 
-                resolved_paths.append(abs_user_path)
+                yield abs_user_path
             elif os.path.isdir(abs_user_path):
-                for grouping in os.walk(abs_user_path, topdown=True, followlinks=follow_symlinks):
-                    dirpath, _, filenames = grouping
+                if not follow_symlinks and os.path.islink(abs_user_path):
+                    if logger:
+                        logger.debug("Skipping symlinked directory %s", abs_user_path)
+                    continue
+
+                for dirpath, dirnames, filenames in os.walk(abs_user_path, topdown=True, followlinks=follow_symlinks):
+                    PathUtil.prune_excluded_directories(dirpath, dirnames, excludes)
 
                     # TODO: add option to include hidden files
-                    # TODO: add support for include/exclude path filters
-                    product_paths = [
-                        os.path.join(dirpath, filename)
-                        for filename in filter(lambda name: not name.startswith("."), filenames)
-                    ]
+                    for filename in filter(lambda name: not name.startswith("."), filenames):
+                        file_path = os.path.join(dirpath, filename)
 
-                    resolved_paths = PathUtil.resolve_ingress_paths(
-                        product_paths, includes, excludes, pbar, resolved_paths, follow_symlinks=follow_symlinks
-                    )
-            else:
+                        if not follow_symlinks and os.path.islink(file_path):
+                            if logger:
+                                logger.debug("Skipping symlinked file %s", file_path)
+                            continue
+
+                        if PathUtil.filter_file(file_path, includes, excludes):
+                            if logger:
+                                logger.debug("Filtering path %s based on include/exclude filters", file_path)
+                            continue
+
+                        yield file_path
+            elif logger:
                 logger.warning("Encountered path (%s) that is neither a file nor directory, skipping...", abs_user_path)
-                pbar.update()
 
-        return resolved_paths
+    @staticmethod
+    def prune_excluded_directories(dirpath, dirnames, excludes):
+        """
+        Prunes excluded child directories from an os.walk() dirnames list.
+
+        Parameters
+        ----------
+        dirpath : str
+            Directory currently being walked.
+        dirnames : list of str
+            Child directory names from os.walk(). This list is modified in place.
+        excludes : list of str
+            List of exclude patterns to apply.
+
+        """
+        if not excludes:
+            return
+
+        dirnames[:] = [
+            dirname
+            for dirname in dirnames
+            if not PathUtil.filter_directory(os.path.join(dirpath, dirname), excludes)
+        ]
+
+    @staticmethod
+    def filter_directory(dir_path, excludes):
+        """
+        Determines if the provided directory path should be pruned based on
+        exclude patterns.
+
+        Parameters
+        ----------
+        dir_path : str
+            The directory path to filter.
+        excludes : list of str
+            List of exclude patterns to apply.
+
+        Returns
+        -------
+        bool
+            True if the directory should be pruned, False otherwise.
+
+        """
+        if not excludes:
+            return False
+
+        normalized_dir_path = os.path.normpath(dir_path)
+        for pattern in excludes:
+            normalized_pattern = os.path.normpath(pattern)
+            if fnmatch.fnmatch(normalized_dir_path, normalized_pattern):
+                return True
+
+        return False
 
     @staticmethod
     def trim_ingress_path(ingress_path, prefix=None):

--- a/src/pds/ingress/util/path_util.py
+++ b/src/pds/ingress/util/path_util.py
@@ -138,6 +138,11 @@ class PathUtil:
                         logger.debug("Skipping symlinked directory %s", abs_user_path)
                     continue
 
+                if PathUtil.filter_directory(abs_user_path, excludes):
+                    if logger:
+                        logger.debug("Filtering directory %s based on exclude filters", abs_user_path)
+                    continue
+
                 for dirpath, dirnames, filenames in os.walk(abs_user_path, topdown=True, followlinks=follow_symlinks):
                     PathUtil.prune_excluded_directories(dirpath, dirnames, excludes)
 

--- a/src/pds/ingress/util/progress_util.py
+++ b/src/pds/ingress/util/progress_util.py
@@ -9,10 +9,9 @@ states of an upload request.
 """
 import multiprocessing
 
+from pds.ingress.util.path_util import PathUtil
 from tqdm import tqdm
 from tqdm.asyncio import tqdm_asyncio
-
-from pds.ingress.util.path_util import PathUtil
 
 PATH_BAR = None
 MANIFEST_BAR = None

--- a/src/pds/ingress/util/progress_util.py
+++ b/src/pds/ingress/util/progress_util.py
@@ -8,10 +8,11 @@ states of an upload request.
 
 """
 import multiprocessing
-import os
 
 from tqdm import tqdm
 from tqdm.asyncio import tqdm_asyncio
+
+from pds.ingress.util.path_util import PathUtil
 
 PATH_BAR = None
 MANIFEST_BAR = None
@@ -25,7 +26,7 @@ LIGHT_GREEN = "#05E520"
 """Hex code for a light green color"""
 
 
-def get_path_progress_bar(user_paths):
+def get_path_progress_bar(user_paths, includes=None, excludes=None, follow_symlinks=True):
     """
     Initializes (if necessary) and returns the Path Resolution progress bar using
     the number of files to be resolved for ingress.
@@ -34,6 +35,12 @@ def get_path_progress_bar(user_paths):
     ----------
     user_paths : list of str
         The list of paths to resolve provided by the user on the command-line.
+    includes : list of str, optional
+        List of patterns defining which files to include for ingress.
+    excludes : list of str, optional
+        List of patterns defining which files to exclude from ingress.
+    follow_symlinks : bool, optional
+        Whether to follow symbolic links when walking directories.
 
     Returns
     -------
@@ -44,13 +51,9 @@ def get_path_progress_bar(user_paths):
     global PATH_BAR
 
     if PATH_BAR is None:
-        total_files = 0
-
-        for user_path in user_paths:
-            abs_user_path = os.path.abspath(user_path)
-            for _, _, files in os.walk(abs_user_path):
-                # Ignore hidden files
-                total_files += len([file for file in files if not file.startswith(".")])
+        includes = includes or []
+        excludes = excludes or []
+        total_files = PathUtil.count_resolvable_ingress_paths(user_paths, includes, excludes, follow_symlinks)
 
         PATH_BAR = tqdm(
             total=total_files,

--- a/tests/pds/ingress/util/test_path_util.py
+++ b/tests/pds/ingress/util/test_path_util.py
@@ -7,6 +7,7 @@ from os.path import abspath
 from os.path import join
 from pathlib import Path
 
+from pds.ingress.util import progress_util
 from pds.ingress.util.path_util import PathUtil
 from pds.ingress.util.progress_util import get_path_progress_bar
 
@@ -27,6 +28,7 @@ class PathUtilTest(unittest.TestCase):
 
     def setUp(self) -> None:
         """Create a temporary directory that each test can populate as necessary"""
+        progress_util.PATH_BAR = None
         self.working_dir = tempfile.TemporaryDirectory(prefix="test_path_util_", suffix="_temp", dir=os.curdir)
 
     def tearDown(self) -> None:
@@ -140,6 +142,94 @@ class PathUtilTest(unittest.TestCase):
         self.assertNotIn(abspath(join(self.working_dir.name, "data.txt")), resolved_ingress_paths)
         self.assertNotIn(abspath(join(self.working_dir.name, "data.xml")), resolved_ingress_paths)
 
+    def test_excluded_directories_are_pruned_during_path_resolution(self):
+        """Test that excluded directories are not walked during path resolution"""
+        included_dir = join(self.working_dir.name, "included")
+        excluded_dir = join(self.working_dir.name, "excluded")
+        nested_excluded_dir = join(excluded_dir, "nested")
+
+        os.makedirs(included_dir)
+        os.makedirs(nested_excluded_dir)
+        Path(included_dir, "included.txt").touch()
+        Path(excluded_dir, "excluded.txt").touch()
+        Path(nested_excluded_dir, "nested_excluded.txt").touch()
+
+        excludes = [abspath(excluded_dir)]
+
+        with get_path_progress_bar([self.working_dir.name], [], excludes) as pbar:
+            resolved_ingress_paths = PathUtil.resolve_ingress_paths([self.working_dir.name], [], excludes, pbar)
+
+        self.assertEqual(pbar.total, 1)
+        self.assertEqual(pbar.n, 1)
+        self.assertEqual(len(resolved_ingress_paths), 1)
+        self.assertIn(abspath(join(included_dir, "included.txt")), resolved_ingress_paths)
+        self.assertNotIn(abspath(join(excluded_dir, "excluded.txt")), resolved_ingress_paths)
+        self.assertNotIn(abspath(join(nested_excluded_dir, "nested_excluded.txt")), resolved_ingress_paths)
+
+    def test_count_resolvable_ingress_paths_respects_excluded_directories(self):
+        """Test that the path progress total ignores pruned excluded directories"""
+        included_dir = join(self.working_dir.name, "included")
+        excluded_dir = join(self.working_dir.name, "excluded")
+        nested_excluded_dir = join(excluded_dir, "nested")
+
+        os.makedirs(included_dir)
+        os.makedirs(nested_excluded_dir)
+        Path(included_dir, "included.txt").touch()
+        Path(excluded_dir, "excluded.txt").touch()
+        Path(nested_excluded_dir, "nested_excluded.txt").touch()
+
+        excludes = [abspath(excluded_dir)]
+
+        self.assertEqual(PathUtil.count_resolvable_ingress_paths([self.working_dir.name], [], excludes), 1)
+
+    def test_deep_exclude_globs_do_not_prune_parent_directories(self):
+        """Test that descendant exclude globs do not prune their parent directories"""
+        included_dir = join(self.working_dir.name, "included")
+        excluded_dir = join(self.working_dir.name, "excluded")
+
+        os.makedirs(included_dir)
+        os.makedirs(excluded_dir)
+        Path(included_dir, "included.dat").touch()
+        Path(excluded_dir, "excluded.dat").touch()
+        Path(excluded_dir, "excluded.tmp").touch()
+
+        excludes = [join(abspath(excluded_dir), "*.tmp")]
+
+        with get_path_progress_bar([self.working_dir.name], [], excludes) as pbar:
+            resolved_ingress_paths = PathUtil.resolve_ingress_paths([self.working_dir.name], [], excludes, pbar)
+
+        self.assertEqual(pbar.total, 2)
+        self.assertEqual(pbar.n, 2)
+        self.assertEqual(len(resolved_ingress_paths), 2)
+        self.assertIn(abspath(join(included_dir, "included.dat")), resolved_ingress_paths)
+        self.assertIn(abspath(join(excluded_dir, "excluded.dat")), resolved_ingress_paths)
+        self.assertNotIn(abspath(join(excluded_dir, "excluded.tmp")), resolved_ingress_paths)
+
+    def test_nested_include_and_exclude_filters_share_count_and_resolution_semantics(self):
+        """Test that nested include and exclude filters agree in count and resolution paths"""
+        included_dir = join(self.working_dir.name, "bundle", "included")
+        excluded_dir = join(self.working_dir.name, "bundle", "excluded")
+
+        os.makedirs(included_dir)
+        os.makedirs(excluded_dir)
+        Path(included_dir, "keep.xml").touch()
+        Path(included_dir, "skip.dat").touch()
+        Path(excluded_dir, "drop.xml").touch()
+
+        includes = [join(abspath(self.working_dir.name), "bundle", "*", "*.xml")]
+        excludes = [abspath(excluded_dir)]
+
+        with get_path_progress_bar([self.working_dir.name], includes, excludes) as pbar:
+            resolved_ingress_paths = PathUtil.resolve_ingress_paths([self.working_dir.name], includes, excludes, pbar)
+
+        self.assertEqual(PathUtil.count_resolvable_ingress_paths([self.working_dir.name], includes, excludes), 1)
+        self.assertEqual(pbar.total, 1)
+        self.assertEqual(pbar.n, 1)
+        self.assertEqual(len(resolved_ingress_paths), 1)
+        self.assertIn(abspath(join(included_dir, "keep.xml")), resolved_ingress_paths)
+        self.assertNotIn(abspath(join(included_dir, "skip.dat")), resolved_ingress_paths)
+        self.assertNotIn(abspath(join(excluded_dir, "drop.xml")), resolved_ingress_paths)
+
     def test_trim_ingress_path(self):
         """Test the trim_ingress_path() function"""
         ingress_paths = [
@@ -251,6 +341,20 @@ class PathUtilTest(unittest.TestCase):
         self.assertNotIn(abspath(join(symlink_dir, "real_file.txt")), resolved_paths)
         # Symlinked file should not be included
         self.assertNotIn(abspath(symlink_file), resolved_paths)
+        self.assertEqual(
+            PathUtil.count_resolvable_ingress_paths([self.working_dir.name], [], [], follow_symlinks=False),
+            2,
+        )
+
+        # A symlinked directory provided directly as a top-level path should also be
+        # skipped when follow_symlinks=False, matching the symlinked file behavior
+        progress_util.PATH_BAR = None
+        with get_path_progress_bar([symlink_dir], [], [], follow_symlinks=False) as pbar:
+            resolved_paths = PathUtil.resolve_ingress_paths([symlink_dir], [], [], pbar, follow_symlinks=False)
+
+        self.assertEqual(pbar.total, 0)
+        self.assertEqual(pbar.n, 0)
+        self.assertEqual(len(resolved_paths), 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->
## 🗒️ Summary

Updates ingress path resolution so excluded directory trees are pruned before traversal instead of being walked and filtered only after child files are discovered. This keeps excluded files out of path resolution, checksum manifest preparation, backend verification, and upload work.

Also updates path-resolution progress totals to use the same include/exclude/symlink-aware traversal logic as resolution, documents directory-pruning semantics, and adds regression coverage for directory excludes, deep file globs, include/exclude interaction, and symlink skipping.

### 🤖 AI Assistance Disclosure
- [ ] No AI assistance used
- [ ] AI used for light assistance (e.g., suggestions, refactoring, documentation help, minor edits)
- [ ] AI used for moderate content generation (AI generated some code or logic, but the developer authored or heavily revised the majority)
- [x] AI generated substantial portions of this code

Estimated % of code influenced by AI: 100 %

## ⚙️ Test Data and/or Report

### Code

Automated tests added/updated in `tests/pds/ingress/util/test_path_util.py`.

Local verification:

```bash
python -m py_compile src/pds/ingress/util/path_util.py src/pds/ingress/util/progress_util.py src/pds/ingress/client/pds_ingress_client.py tests/pds/ingress/util/test_path_util.py
git diff --check -- src/pds/ingress/util/path_util.py src/pds/ingress/util/progress_util.py src/pds/ingress/client/pds_ingress_client.py tests/pds/ingress/util/test_path_util.py
flake8 src
python -m pytest tests/pds/ingress/util/test_path_util.py
python -m pytest tests
```
Results:
- Path utility tests: `9 passed`
- Full test suite: `36 passed`
- Flake8: passed

### Live Run

Used this updated version of DUM on live data to upload collection inventories and labels in a directory while excluding any data in subdirectories:

```
/opt/dum-dummer/bin/pds-ingress-client --log-level warn --prefix /dsk8/catalina/ -c /home/dum/conf.default.ini -n sbn /dsk8/catalina/gbo.ast.catalina.survey/data_raw --num-threads 12 --report-path /var/log/dum_pipeline/reports/data_raw.json --manifest-path manifests/dsk8_catalina/data_raw/manifest.json --exclude '/dsk8/catalina/gbo.ast.catalina.survey/data_raw/*/*'
```

It had the expected behavior change: Previously, "Resolving ingress paths" would have included all files in excluded directories (in our case, tens of millions of files). Now, it only resolved paths for the expected number of files (2826, due to incrementing collection version every day).
```
Resolving ingress paths: 100%|████████████████████████████████████████████████████████████| 2826/2826 Files
```

## ♻️ Related Issues

No GitHub issue was provided for this change.

## 🤓 Reviewer Checklist

*Reviewers: Please verify the following before approving this pull request.*

### Documentation and PR Content
- [ ] **Documentation:** README, Wiki, or inline documentation (Sphinx, Javadoc, Docstrings) have been updated to reflect these changes.
- [ ] **Issue Traceability:** The PR is linked to a valid GitHub Issue
- [ ] **PR Title:** The PR title is "user-friendly" clearly identifying what is being fixed or the new feature being added, that if you saw it in the Release Notes for a tool, you would be able to get the gist of what was done.

### Security & Quality
- [ ] **SonarCloud:** Confirmed no new High or Critical security findings.
- [ ] **Secrets Detection:** Verified that the Secrets Detection scan passed and no sensitive information (keys, tokens, PII) is exposed.
- [ ] **Code Quality:** Code follows organization style guidelines and best practices for the specific language (e.g., PEP 8, Google Java Style).

### Testing & Validation
- [ ] **Test Accuracy:** Verified that test data is accurate, representative of real-world PDS4 scenarios, and sufficient for the logic being tested.
- [ ] **Coverage:** Automated tests cover new logic and edge cases.
- [ ] **Local Verification:** (If applicable) Successfully built and ran the changes in a local or staging environment.

### Maintenance
- [ ] **Backward Compatibility:** Confirmed that these changes do not break existing downstream dependencies or API contracts (or that breaking changes are clearly documented).
