### PR TITLE
Warn user and exit when nonexistent ingress paths are supplied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 **Defects:**
 
+- DUM does not verify file path for weblog uploads [\#365](https://github.com/NASA-PDS/data-upload-manager/issues/365)
 - DUM v2.4.2 CloudWatch Logs SerializationException Errors [\#352](https://github.com/NASA-PDS/data-upload-manager/issues/352) [[s.medium](https://github.com/NASA-PDS/data-upload-manager/labels/s.medium)]
 
 ## [v2.5.5](https://github.com/NASA-PDS/data-upload-manager/tree/v2.5.5) (2026-04-22)

--- a/src/pds/ingress/client/pds_ingress_client.py
+++ b/src/pds/ingress/client/pds_ingress_client.py
@@ -935,6 +935,14 @@ def main(args):
         )
     close_path_progress_bar()
 
+    nonexistent_paths = [p for p in args.ingress_paths if not os.path.exists(os.path.abspath(p))]
+    if nonexistent_paths:
+        for p in nonexistent_paths:
+            logger.warning(Color.yellow("Path does not exist and will be skipped: %s"), p)
+        if not resolved_ingress_paths:
+            logger.error("No valid ingress paths found. Exiting.")
+            sys.exit(1)
+
     # Initialize the summary table, and populate the "unprocessed" table the set
     # of resolved ingress paths
     SUMMARY_TABLE = initialize_summary_table()

--- a/src/pds/ingress/client/pds_ingress_client.py
+++ b/src/pds/ingress/client/pds_ingress_client.py
@@ -38,6 +38,7 @@ from pds.ingress.util.node_util import NodeUtil
 from pds.ingress.util.path_util import PathUtil
 from pds.ingress.util.progress_util import close_batch_progress_bars
 from pds.ingress.util.progress_util import close_ingress_total_progress_bar
+from pds.ingress.util.progress_util import close_path_progress_bar
 from pds.ingress.util.progress_util import get_available_batch_progress_bar
 from pds.ingress.util.progress_util import get_ingress_total_progress_bar
 from pds.ingress.util.progress_util import get_manifest_progress_bar
@@ -932,6 +933,7 @@ def main(args):
         resolved_ingress_paths = PathUtil.resolve_ingress_paths(
             args.ingress_paths, args.includes, args.excludes, pbar, follow_symlinks=follow_symlinks
         )
+    close_path_progress_bar()
 
     # Initialize the summary table, and populate the "unprocessed" table the set
     # of resolved ingress paths

--- a/src/pds/ingress/util/path_util.py
+++ b/src/pds/ingress/util/path_util.py
@@ -76,8 +76,8 @@ class PathUtil:
         # Use a logger with no console output to avoid interfering with tqdm output
         logger = get_logger("resove_ingress_paths", console=False)
 
-        # Initialize the list of resolved paths if necessary
-        resolved_paths = resolved_paths or list()
+        if resolved_paths is None:
+            resolved_paths = list()
 
         for ingress_path in PathUtil._iter_resolvable_ingress_paths(
             user_paths, includes, excludes, follow_symlinks, logger

--- a/src/pds/ingress/util/path_util.py
+++ b/src/pds/ingress/util/path_util.py
@@ -74,7 +74,7 @@ class PathUtil:
 
         """
         # Use a logger with no console output to avoid interfering with tqdm output
-        logger = get_logger("resove_ingress_paths", console=False)
+        logger = get_logger("resolve_ingress_paths", console=False)
 
         if resolved_paths is None:
             resolved_paths = list()

--- a/src/pds/ingress/util/progress_util.py
+++ b/src/pds/ingress/util/progress_util.py
@@ -54,7 +54,7 @@ def get_path_progress_bar(user_paths, includes=None, excludes=None, follow_symli
     excludes = excludes or []
     call_params = (tuple(user_paths), tuple(includes), tuple(excludes), follow_symlinks)
 
-    if PATH_BAR is None or getattr(PATH_BAR, "disable", False) or _PATH_BAR_PARAMS != call_params:
+    if PATH_BAR is None or _PATH_BAR_PARAMS != call_params:
         if PATH_BAR is not None:
             PATH_BAR.close()
         total_files = PathUtil.count_resolvable_ingress_paths(user_paths, includes, excludes, follow_symlinks)
@@ -70,6 +70,16 @@ def get_path_progress_bar(user_paths, includes=None, excludes=None, follow_symli
         _PATH_BAR_PARAMS = call_params
 
     return PATH_BAR
+
+
+def close_path_progress_bar():
+    """Closes the Path Resolution progress bar and resets global state."""
+    global PATH_BAR, _PATH_BAR_PARAMS
+
+    if PATH_BAR is not None:
+        PATH_BAR.close()
+        PATH_BAR = None
+    _PATH_BAR_PARAMS = None
 
 
 def get_manifest_progress_bar(total):

--- a/src/pds/ingress/util/progress_util.py
+++ b/src/pds/ingress/util/progress_util.py
@@ -54,7 +54,7 @@ def get_path_progress_bar(user_paths, includes=None, excludes=None, follow_symli
     excludes = excludes or []
     call_params = (tuple(user_paths), tuple(includes), tuple(excludes), follow_symlinks)
 
-    if PATH_BAR is None or _PATH_BAR_PARAMS != call_params:
+    if PATH_BAR is None or getattr(PATH_BAR, "disable", False) or _PATH_BAR_PARAMS != call_params:
         if PATH_BAR is not None:
             PATH_BAR.close()
         total_files = PathUtil.count_resolvable_ingress_paths(user_paths, includes, excludes, follow_symlinks)

--- a/src/pds/ingress/util/progress_util.py
+++ b/src/pds/ingress/util/progress_util.py
@@ -14,6 +14,7 @@ from tqdm import tqdm
 from tqdm.asyncio import tqdm_asyncio
 
 PATH_BAR = None
+_PATH_BAR_PARAMS = None  # (user_paths_tuple, includes_tuple, excludes_tuple, follow_symlinks) used to build PATH_BAR
 MANIFEST_BAR = None
 TOTAL_INGRESS_BAR = None
 BATCH_BARS = []
@@ -47,11 +48,15 @@ def get_path_progress_bar(user_paths, includes=None, excludes=None, follow_symli
         The initialized global instance of the Path Resolution progress bar.
 
     """
-    global PATH_BAR
+    global PATH_BAR, _PATH_BAR_PARAMS
 
-    if PATH_BAR is None:
-        includes = includes or []
-        excludes = excludes or []
+    includes = includes or []
+    excludes = excludes or []
+    call_params = (tuple(user_paths), tuple(includes), tuple(excludes), follow_symlinks)
+
+    if PATH_BAR is None or _PATH_BAR_PARAMS != call_params:
+        if PATH_BAR is not None:
+            PATH_BAR.close()
         total_files = PathUtil.count_resolvable_ingress_paths(user_paths, includes, excludes, follow_symlinks)
 
         PATH_BAR = tqdm(
@@ -62,6 +67,7 @@ def get_path_progress_bar(user_paths, includes=None, excludes=None, follow_symli
             colour=LIGHT_GREEN,
             bar_format="{l_bar}{bar:60}| {n_fmt}/{total_fmt} Files",
         )
+        _PATH_BAR_PARAMS = call_params
 
     return PATH_BAR
 

--- a/tests/pds/ingress/util/test_path_util.py
+++ b/tests/pds/ingress/util/test_path_util.py
@@ -7,8 +7,8 @@ from os.path import abspath
 from os.path import join
 from pathlib import Path
 
-from pds.ingress.util import progress_util
 from pds.ingress.util.path_util import PathUtil
+from pds.ingress.util.progress_util import close_path_progress_bar
 from pds.ingress.util.progress_util import get_path_progress_bar
 
 
@@ -28,8 +28,7 @@ class PathUtilTest(unittest.TestCase):
 
     def setUp(self) -> None:
         """Create a temporary directory that each test can populate as necessary"""
-        progress_util.PATH_BAR = None
-        progress_util._PATH_BAR_PARAMS = None
+        close_path_progress_bar()
         self.working_dir = tempfile.TemporaryDirectory(prefix="test_path_util_", suffix="_temp", dir=os.curdir)
 
     def tearDown(self) -> None:
@@ -259,10 +258,7 @@ class PathUtilTest(unittest.TestCase):
             self.assertEqual(second_total, 1)
             self.assertIsNot(first_bar, second_bar)
         finally:
-            if progress_util.PATH_BAR is not None:
-                progress_util.PATH_BAR.close()
-                progress_util.PATH_BAR = None
-            progress_util._PATH_BAR_PARAMS = None
+            close_path_progress_bar()
 
     def test_trim_ingress_path(self):
         """Test the trim_ingress_path() function"""
@@ -382,7 +378,7 @@ class PathUtilTest(unittest.TestCase):
 
         # A symlinked directory provided directly as a top-level path should also be
         # skipped when follow_symlinks=False, matching the symlinked file behavior
-        progress_util.PATH_BAR = None
+        close_path_progress_bar()
         with get_path_progress_bar([symlink_dir], [], [], follow_symlinks=False) as pbar:
             resolved_paths = PathUtil.resolve_ingress_paths([symlink_dir], [], [], pbar, follow_symlinks=False)
 

--- a/tests/pds/ingress/util/test_path_util.py
+++ b/tests/pds/ingress/util/test_path_util.py
@@ -29,6 +29,7 @@ class PathUtilTest(unittest.TestCase):
     def setUp(self) -> None:
         """Create a temporary directory that each test can populate as necessary"""
         progress_util.PATH_BAR = None
+        progress_util._PATH_BAR_PARAMS = None
         self.working_dir = tempfile.TemporaryDirectory(prefix="test_path_util_", suffix="_temp", dir=os.curdir)
 
     def tearDown(self) -> None:
@@ -246,18 +247,22 @@ class PathUtilTest(unittest.TestCase):
         Path(self.working_dir.name, "keep.txt").touch()
         Path(self.working_dir.name, "drop.xml").touch()
 
-        with get_path_progress_bar([self.working_dir.name], [], []) as first_bar:
+        excludes = [join(abspath(self.working_dir.name), "*.xml")]
+        try:
+            first_bar = get_path_progress_bar([self.working_dir.name], [], [])
             first_total = first_bar.total
 
-        progress_util.PATH_BAR = None
-        progress_util._PATH_BAR_PARAMS = None
-
-        excludes = [join(abspath(self.working_dir.name), "*.xml")]
-        with get_path_progress_bar([self.working_dir.name], [], excludes) as second_bar:
+            second_bar = get_path_progress_bar([self.working_dir.name], [], excludes)
             second_total = second_bar.total
 
-        self.assertEqual(first_total, 2)
-        self.assertEqual(second_total, 1)
+            self.assertEqual(first_total, 2)
+            self.assertEqual(second_total, 1)
+            self.assertIsNot(first_bar, second_bar)
+        finally:
+            if progress_util.PATH_BAR is not None:
+                progress_util.PATH_BAR.close()
+                progress_util.PATH_BAR = None
+            progress_util._PATH_BAR_PARAMS = None
 
     def test_trim_ingress_path(self):
         """Test the trim_ingress_path() function"""

--- a/tests/pds/ingress/util/test_path_util.py
+++ b/tests/pds/ingress/util/test_path_util.py
@@ -230,6 +230,35 @@ class PathUtilTest(unittest.TestCase):
         self.assertNotIn(abspath(join(included_dir, "skip.dat")), resolved_ingress_paths)
         self.assertNotIn(abspath(join(excluded_dir, "drop.xml")), resolved_ingress_paths)
 
+    def test_resolve_ingress_paths_preserves_explicitly_passed_empty_list(self):
+        """Test that resolve_ingress_paths() does not replace an explicitly passed [] with a new list"""
+        Path(self.working_dir.name, "file.txt").touch()
+
+        caller_list = []
+        with get_path_progress_bar([self.working_dir.name]) as pbar:
+            result = PathUtil.resolve_ingress_paths([self.working_dir.name], [], [], pbar, resolved_paths=caller_list)
+
+        self.assertIs(result, caller_list)
+        self.assertEqual(len(result), 1)
+
+    def test_get_path_progress_bar_recomputes_total_for_different_params(self):
+        """Test that get_path_progress_bar() recomputes total when called with different filter parameters"""
+        Path(self.working_dir.name, "keep.txt").touch()
+        Path(self.working_dir.name, "drop.xml").touch()
+
+        with get_path_progress_bar([self.working_dir.name], [], []) as first_bar:
+            first_total = first_bar.total
+
+        progress_util.PATH_BAR = None
+        progress_util._PATH_BAR_PARAMS = None
+
+        excludes = [join(abspath(self.working_dir.name), "*.xml")]
+        with get_path_progress_bar([self.working_dir.name], [], excludes) as second_bar:
+            second_total = second_bar.total
+
+        self.assertEqual(first_total, 2)
+        self.assertEqual(second_total, 1)
+
     def test_trim_ingress_path(self):
         """Test the trim_ingress_path() function"""
         ingress_paths = [


### PR DESCRIPTION
## 🗒️ Summary

When the user supplies a path that does not exist on disk, `pds-ingress-client` previously resolved it silently (a warning went only to the log file) and proceeded with an empty batch — producing confusing output like `1/0 Files` in the progress bar and a successful-looking summary reporting 0 uploaded files.

This PR adds a post-resolution check in `main()`:

- For **each nonexistent path**, a visible `WARNING` is emitted to the console (yellow, via the existing `Color.yellow()` helper).
- If **no files were resolved at all** (every supplied path was nonexistent), the client logs an error and exits with code 1 rather than running through authentication and batch setup for nothing.

Paths that do exist are still processed normally, so mixed inputs (some valid, some not) degrade gracefully with a warning rather than a hard stop.

### 🤖 AI Assistance Disclosure
- [ ] No AI assistance used
- [ ] AI used for light assistance (e.g., suggestions, refactoring, documentation help, minor edits)
- [ ] AI used for moderate content generation (AI generated some code or logic, but the developer authored or heavily revised the majority)
- [x] AI generated substantial portions of this code

Estimated % of code influenced by AI: 90%

## ⚙️ Test Data and/or Report

Manual verification against the reproduction case in the issue:

```
pds-ingress-client ~/this/is/a/path/with/a/TYPOOO/ \
    --prefix ~/this/is/a/path/ \
    --config-path ~/correct/path/to/config.ini \
    --node eng \
    --weblogs foo
```

Expected new output:
```
WARNING  Path does not exist and will be skipped: /Users/.../TYPOOO/
ERROR    No valid ingress paths found. Exiting.
```

All existing unit tests pass: `tox -e py313 -- tests/pds/ingress/util/test_path_util.py` (11/11).

## ♻️ Related Issues

Fixes #365

## 🤓 Reviewer Checklist

*Reviewers: Please verify the following before approving this pull request.*

### Documentation and PR Content
- [ ] **Documentation:** README, Wiki, or inline documentation (Sphinx, Javadoc, Docstrings) have been updated to reflect these changes.
- [ ] **Issue Traceability:** The PR is linked to a valid GitHub Issue
- [ ] **PR Title:** The PR title is "user-friendly" clearly identifying what is being fixed or the new feature being added, that if you saw it in the Release Notes for a tool, you would be able to get the gist of what was done.

### Security & Quality
- [ ] **SonarCloud:** Confirmed no new High or Critical security findings.
- [ ] **Secrets Detection:** Verified that the Secrets Detection scan passed and no sensitive information (keys, tokens, PII) is exposed.
- [ ] **Code Quality:** Code follows organization style guidelines and best practices for the specific language (e.g., PEP 8, Google Java Style).

### Testing & Validation
- [ ] **Test Accuracy:** Verified that test data is accurate, representative of real-world PDS4 scenarios, and sufficient for the logic being tested.
- [ ] **Coverage:** Automated tests cover new logic and edge cases.
- [ ] **Local Verification:** (If applicable) Successfully built and ran the changes in a local or staging environment.

### Maintenance
- [ ] **Backward Compatibility:** Confirmed that these changes do not break existing downstream dependencies or API contracts (or that breaking changes are clearly documented).
