### PR TITLE
Add clear documentation for uploading weblogs

### DIFF
--- a/docs/source/usage/index.rst
+++ b/docs/source/usage/index.rst
@@ -276,7 +276,7 @@ Before uploading weblogs, ensure the following:
 2. **Log files are gzip-compressed** — every file must have a ``.gz`` extension. The client
    will reject the entire upload if any non-gzipped file is detected.
 3. **You know your node ID** — one of ``atm``, ``eng``, ``geo``, ``img``, ``naif``, ``ppi``,
-   ``rs``, ``rms``, ``sbn``.
+   ``rms``, ``sbn``.
 
 Compressing Log Files
 ^^^^^^^^^^^^^^^^^^^^^
@@ -297,9 +297,10 @@ identifies the type of web server generating the logs (e.g., ``apache``, ``nginx
 
 **Required arguments for weblog uploads:**
 
+- ``--node NODE_ID`` — your PDS node identifier
 - ``--weblogs LOG_TYPE`` — designates the upload as weblogs and specifies the log type
 - ``--prefix PATH`` — the local path prefix to strip from uploaded file paths
-- ``--node NODE_ID`` — your PDS node identifier
+- ``file_or_dir`` - the local path of the files to upload. The value for ``--prefix PATH`` is a substring of this value
 
 **Example:**
 
@@ -422,3 +423,18 @@ Add ``--prefix /your/local/log/directory`` to the command.
 .. References:
 .. _backoff: https://pypi.org/project/backoff/
 .. _installation: ../installation/index.html
+
+**Upload fails with "401 (Unauthorized)" message**
+
+You have an account but do not have access to the node which you've identified yourself as (e.g., ``--node img``)::
+
+    Performing Cognito authentication for user <username>    
+    Authentication successful
+    ...
+    ----------------------------------------------
+    Ingress request failed with HTTP status 401 (Unauthorized)
+    You are not authorized to use the ingestion service (401 Unauthorized).
+    Your account may not be in the required user group.
+    Please contact PDS Engineering for access.
+
+Contact PDS Engineering with the node of which you are a member and require access to.

--- a/docs/source/usage/index.rst
+++ b/docs/source/usage/index.rst
@@ -424,7 +424,7 @@ Add ``--prefix /your/local/log/directory`` to the command.
 
 You have an account but do not have access to the node which you've identified yourself as (e.g., ``--node img``)::
 
-    Performing Cognito authentication for user <username>    
+    Performing Cognito authentication for user <username>
     Authentication successful
     ...
     ----------------------------------------------

--- a/docs/source/usage/index.rst
+++ b/docs/source/usage/index.rst
@@ -78,8 +78,9 @@ in AWS would resolve to ``bundle/file.xml``.
 The ``--weblogs LOG_TYPE`` argument can be used to indicate that weblog files are being uploaded.
 The type of log files (e.g. ``apache``, ``nginx``, etc.) should be specified as the
 ``LOG_TYPE`` argument. When this flag is provided, the client will automatically adjust
-the "trimmed" path for each ingested file to replace the specified path prefix with ``weblog/``,
-ensuring that all weblog files are routed to a specific S3 bucket used for web analytics.
+the "trimmed" path for each ingested file to replace the specified path prefix with
+``weblogs/<node>-<log_type>/``, ensuring that all weblog files are routed to the S3
+bucket used for web analytics.
 Because of this, the ``--prefix`` argument must be provided when using the ``--weblogs`` argument.
 
 .. warning::
@@ -95,6 +96,8 @@ Because of this, the ``--prefix`` argument must be provided when using the ``--w
 
    1. Compress all files with gzip before uploading, or
    2. Use the ``--exclude`` argument to filter out non-gzipped files (e.g., ``--exclude "*.txt"``)
+
+See the `Uploading Weblogs`_ section below for a complete walkthrough.
 
 The ``pds-ingress-client`` by default utilizes all available CPUs on the
 local machine to perform parallelized ingress requests to the ingress service. The exact
@@ -256,6 +259,165 @@ Files that still fail to upload during this final attempt are recorded in the fi
     Bytes transferred: 0
 
 Should persistent failures like this occur, they should be communicated to the PDS Operations team for investigation.
+
+Uploading Weblogs
+-----------------
+
+PDS nodes can upload web server log files directly to the PDS web analytics S3 bucket using the
+``--weblogs`` flag. This section walks through the full process.
+
+Prerequisites
+^^^^^^^^^^^^^
+
+Before uploading weblogs, ensure the following:
+
+1. **Your DUM client is installed and configured** — see the installation_ instructions for
+   creating your INI config file.
+2. **Log files are gzip-compressed** — every file must have a ``.gz`` extension. The client
+   will reject the entire upload if any non-gzipped file is detected.
+3. **You know your node ID** — one of ``atm``, ``eng``, ``geo``, ``img``, ``naif``, ``ppi``,
+   ``rs``, ``rms``, ``sbn``.
+
+Compressing Log Files
+^^^^^^^^^^^^^^^^^^^^^
+
+If your log files are not already compressed, gzip them before uploading::
+
+    $ gzip /path/to/logs/access.log
+    $ gzip /path/to/logs/*.log
+
+This produces files with a ``.gz`` extension (e.g., ``access.log.gz``).
+
+Uploading
+^^^^^^^^^
+
+Use the ``--weblogs LOG_TYPE`` argument along with ``--prefix`` to upload weblogs. ``LOG_TYPE``
+identifies the type of web server generating the logs (e.g., ``apache``, ``nginx``, ``iis``,
+``tomcat``). The value is case-insensitive and becomes part of the S3 destination path.
+
+**Required arguments for weblog uploads:**
+
+- ``--weblogs LOG_TYPE`` — designates the upload as weblogs and specifies the log type
+- ``--prefix PATH`` — the local path prefix to strip from uploaded file paths
+- ``--node NODE_ID`` — your PDS node identifier
+
+**Example:**
+
+Suppose your compressed log files are stored under ``/data/weblogs/`` and you want to upload
+them on behalf of the SBN node using Apache-format logs::
+
+    $ pds-ingress-client \
+        -c /path/to/config.ini \
+        --node sbn \
+        --weblogs apache \
+        --prefix /data/weblogs \
+        -- /data/weblogs/
+
+How the Destination Path Is Constructed
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When ``--weblogs`` is specified, the client replaces the ``--prefix`` value in each file path
+with ``weblogs/<node>-<log_type>/``. For example, with ``--node sbn``, ``--weblogs apache``,
+and ``--prefix /data/weblogs``, a local file at:
+
+.. code-block::
+
+    /data/weblogs/2025/01/access.log.gz
+
+is uploaded to S3 as:
+
+.. code-block::
+
+    weblogs/sbn-apache/2025/01/access.log.gz
+
+Organizing Logs with Subdirectories
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. important::
+
+   The directory structure **below** the ``--prefix`` path is preserved in S3. This means
+   that if all your log files sit directly in ``--prefix`` with no subdirectories, they will
+   all land in a single flat S3 directory. For easier downstream grouping by application,
+   domain, or server, **organize your logs into subdirectories on disk before uploading**.
+
+For example, suppose you host multiple web applications and collect logs from each. Rather
+than keeping all logs flat under ``/data/weblogs/``::
+
+    /data/weblogs/
+    ├── pds.nasa.gov_access.log.gz
+    ├── pds.nasa.gov_error.log.gz
+    ├── sbn.psi.edu_access.log.gz
+    └── sbn.psi.edu_error.log.gz
+
+organize them into subdirectories by application or domain::
+
+    /data/weblogs/
+    ├── pds.nasa.gov/
+    │   ├── access.log.gz
+    │   └── error.log.gz
+    └── sbn.psi.edu/
+        ├── access.log.gz
+        └── error.log.gz
+
+With ``--prefix /data/weblogs``, the second layout uploads to S3 as::
+
+    weblogs/sbn-apache/pds.nasa.gov/access.log.gz
+    weblogs/sbn-apache/pds.nasa.gov/error.log.gz
+    weblogs/sbn-apache/sbn.psi.edu/access.log.gz
+    weblogs/sbn-apache/sbn.psi.edu/error.log.gz
+
+This makes it straightforward to query or process logs for a specific application without
+filtering a large flat directory.
+
+You can also upload logs for a single application at a time by pointing DUM at a specific
+subdirectory and setting ``--prefix`` to its parent::
+
+    $ pds-ingress-client \
+        -c /path/to/config.ini \
+        --node sbn \
+        --weblogs apache \
+        --prefix /data/weblogs \
+        -- /data/weblogs/pds.nasa.gov/
+
+This uploads only ``pds.nasa.gov/`` logs, preserving the subdirectory name in the S3 path.
+
+Verifying Before Upload
+^^^^^^^^^^^^^^^^^^^^^^^
+
+Use ``--dry-run`` to preview which files will be uploaded and confirm the correct set is
+selected, without actually submitting anything::
+
+    $ pds-ingress-client \
+        -c /path/to/config.ini \
+        --node sbn \
+        --weblogs apache \
+        --prefix /data/weblogs \
+        --dry-run \
+        -- /data/weblogs/
+
+Common Issues
+^^^^^^^^^^^^^
+
+**Upload fails with "non-gzipped files" error**
+
+The client checks every file before uploading begins. If any file lacks a ``.gz`` extension,
+you will see an error like::
+
+    ERROR: The following files are not gzipped (.gz):
+      /data/weblogs/access.log
+    ValueError: Weblog uploads require gzipped files. Found 1 non-gzipped file(s). ...
+
+Compress the listed files with ``gzip`` and retry, or use ``--exclude`` to skip them::
+
+    $ pds-ingress-client ... --exclude "*.log" -- /data/weblogs/
+
+**Upload fails with "--prefix must also be provided" error**
+
+The ``--prefix`` argument is required when ``--weblogs`` is used::
+
+    ValueError: When --weblogs is specified, --prefix must also be provided.
+
+Add ``--prefix /your/local/log/directory`` to the command.
 
 .. References:
 .. _backoff: https://pypi.org/project/backoff/

--- a/docs/source/usage/index.rst
+++ b/docs/source/usage/index.rst
@@ -420,10 +420,6 @@ The ``--prefix`` argument is required when ``--weblogs`` is used::
 
 Add ``--prefix /your/local/log/directory`` to the command.
 
-.. References:
-.. _backoff: https://pypi.org/project/backoff/
-.. _installation: ../installation/index.html
-
 **Upload fails with "401 (Unauthorized)" message**
 
 You have an account but do not have access to the node which you've identified yourself as (e.g., ``--node img``)::
@@ -438,3 +434,7 @@ You have an account but do not have access to the node which you've identified y
     Please contact PDS Engineering for access.
 
 Contact PDS Engineering with the node of which you are a member and require access to.
+
+.. References:
+.. _backoff: https://pypi.org/project/backoff/
+.. _installation: ../installation/index.html


### PR DESCRIPTION
## 🗒️ Summary

Adds a dedicated **Uploading Weblogs** section to the usage documentation, providing node operators with a complete walkthrough for uploading web server log files via the `--weblogs` flag. Addresses the acceptance criteria in #366: a new node operator should be able to successfully upload weblogs with minimal help or intervention.

Changes to `docs/source/usage/index.rst`:

- Corrected the inline `--weblogs` description to accurately show the S3 destination path format (`weblogs/<node>-<log_type>/` rather than `weblog/`)
- Added forward reference to the new dedicated section
- Added **Uploading Weblogs** section covering:
  - Prerequisites (DUM config, gzip requirement, node ID)
  - Compressing log files before upload
  - Required arguments and a concrete end-to-end example command
  - How the S3 destination path is constructed from `--prefix`, `--node`, and `--weblogs`
  - **Organizing logs with subdirectories** — guidance on structuring the on-prem filesystem so that the directory hierarchy below `--prefix` is preserved in S3, enabling grouping by application, domain, or server (rather than landing everything in one flat directory)
  - Dry-run verification before upload
  - Common error messages with actionable remediation steps

### 🤖 AI Assistance Disclosure
- [ ] No AI assistance used
- [x] AI used for light assistance (e.g., suggestions, refactoring, documentation help, minor edits)
- [ ] AI used for moderate content generation (AI generated some code or logic, but the developer authored or heavily revised the majority)
- [ ] AI generated substantial portions of this code

Estimated % of code influenced by AI: 80 %

## ⚙️ Test Data and/or Report

Documentation-only change. Verified by building the Sphinx HTML output locally:

```
sphinx-build -b html docs/source docs/build
```

Build result: `build succeeded, 4 warnings` — all 4 warnings are pre-existing (unrelated `argparse` directive and `terraform/index.rst` indentation issues). No new warnings introduced.

Rendered output reviewed via PDF confirming correct formatting of headings, code blocks, warning admonitions, and the important admonition for the subdirectory guidance.

Here is what the output looks like:

<img width="1104" height="912" alt="Screenshot 2026-07-07 at 11 16 05 AM" src="https://github.com/user-attachments/assets/f1127d3f-1e4b-4d7e-bbef-3dc0d054f809" />


<img width="1094" height="912" alt="Screenshot 2026-07-07 at 11 16 22 AM" src="https://github.com/user-attachments/assets/2d6ae503-2239-4e9e-b93e-1d321c978a56" />


<img width="1104" height="873" alt="Screenshot 2026-07-07 at 11 16 34 AM" src="https://github.com/user-attachments/assets/cf69f58b-9c13-4201-9035-86eaca6d9092" />


<img width="1110" height="919" alt="Screenshot 2026-07-07 at 11 16 41 AM" src="https://github.com/user-attachments/assets/036936a1-95d3-4507-b446-699ff01250cc" />



## ♻️ Related Issues

Fixes #366
Refs #232
Refs #330
Refs #231

