### PR TITLE
Fix CloudWatch log submission retrying indefinitely on 401/403 auth failures

### DIFF
--- a/src/pds/ingress/util/log_util.py
+++ b/src/pds/ingress/util/log_util.py
@@ -323,6 +323,15 @@ def setup_cloudwatch_log(logger, config):
     return logger
 
 
+def _is_auth_error(exc):
+    """Returns True for 401/403 HTTP errors that should not be retried."""
+    return (
+        isinstance(exc, requests.exceptions.HTTPError)
+        and exc.response is not None
+        and exc.response.status_code in (401, 403)
+    )
+
+
 class CloudWatchHandler(BufferingHandler):
     """
     Specialization of the BufferingHandler class that submits all buffered log
@@ -420,7 +429,17 @@ class CloudWatchHandler(BufferingHandler):
                             "Localstack context detected, skipping submission of logs to CloudWatch since it is not yet supported"
                         )
             except requests.exceptions.HTTPError as err:
-                raise RuntimeError(f"{str(err)} : {err.response.text}") from err
+                if _is_auth_error(err):
+                    if CONSOLE_HANDLER and not CONSOLE_HANDLER.stream.closed:
+                        console_logger.warning(
+                            "Skipping CloudWatch log submission: not authorized to access the log endpoint (%d). "
+                            "Session logs were not uploaded.",
+                            err.response.status_code,
+                        )
+                    self.buffer.clear()
+                    return
+                response_body = err.response.text if err.response is not None else "(no response body)"
+                raise RuntimeError(f"{str(err)} : {response_body}") from err
 
             self.buffer.clear()
         except Exception as err:
@@ -432,12 +451,7 @@ class CloudWatchHandler(BufferingHandler):
         finally:
             self.release()
 
-    @backoff.on_exception(
-        backoff.expo,
-        Exception,
-        max_time=120,
-        logger=__name__,
-    )
+    @backoff.on_exception(backoff.expo, Exception, max_time=120, logger=__name__, giveup=_is_auth_error)
     def send_log_events_to_cloud_watch(self, log_events):
         """
         Bundles the provided log events into a JSON payload and submits it

--- a/tests/pds/ingress/util/test_log_util.py
+++ b/tests/pds/ingress/util/test_log_util.py
@@ -197,3 +197,56 @@ class LogUtilTest(unittest.TestCase):
 
         # Ensure we retried once for a connection error
         self.assertEqual(mock_requests_post.call_count, 2)
+
+    def test_send_log_events_to_cloud_watch_no_retry_on_auth_error(self):
+        """401 and 403 responses must not be retried — they indicate a permanent auth failure."""
+        logger = log_util.get_logger(
+            "test_send_log_events_to_cloud_watch_no_retry_on_auth_error", console=False, file=False
+        )
+
+        log_util.CLOUDWATCH_HANDLER.bearer_token = "Bearer faketoken"
+        log_util.CLOUDWATCH_HANDLER.node_id = "eng"
+
+        for status_code in (HTTPStatus.UNAUTHORIZED, HTTPStatus.FORBIDDEN):
+            log_util.CLOUDWATCH_HANDLER._stream_created = True
+            # Log via the normal emit() path so record.message is populated by format()
+            logger.info("Test message for %s", status_code)
+
+            auth_response = Response()
+            auth_response.status_code = status_code
+            auth_response._content = b'{"message": "Unauthorized"}'
+
+            mock_requests_post = MagicMock(side_effect=[auth_response])
+
+            with self.assertLogs(level="WARNING") as cm:
+                with patch.object(log_util.requests, "post", mock_requests_post):
+                    log_util.CLOUDWATCH_HANDLER.flush()
+
+            # Must bail after the first attempt — no retries
+            self.assertEqual(mock_requests_post.call_count, 1, f"Expected no retry for {status_code}")
+
+            # Buffer must be cleared even though submission failed
+            self.assertEqual(len(log_util.CLOUDWATCH_HANDLER.buffer), 0, f"Buffer not cleared after {status_code}")
+
+            # User must see a clear warning, not the generic "Unable to submit" message
+            self.assertTrue(
+                any("not authorized" in line.lower() for line in cm.output),
+                f"Expected auth warning in log output for {status_code}, got: {cm.output}",
+            )
+
+    def test_is_auth_error(self):
+        """_is_auth_error returns True only for 401/403 HTTPErrors with a response attached."""
+        auth_response_401 = Response()
+        auth_response_401.status_code = HTTPStatus.UNAUTHORIZED
+
+        auth_response_403 = Response()
+        auth_response_403.status_code = HTTPStatus.FORBIDDEN
+
+        other_response = Response()
+        other_response.status_code = HTTPStatus.INTERNAL_SERVER_ERROR
+
+        self.assertTrue(log_util._is_auth_error(requests.exceptions.HTTPError(response=auth_response_401)))
+        self.assertTrue(log_util._is_auth_error(requests.exceptions.HTTPError(response=auth_response_403)))
+        self.assertFalse(log_util._is_auth_error(requests.exceptions.HTTPError(response=other_response)))
+        self.assertFalse(log_util._is_auth_error(requests.exceptions.HTTPError(response=None)))
+        self.assertFalse(log_util._is_auth_error(ValueError("not an HTTP error")))


### PR DESCRIPTION
## 🗒️ Summary

When an unauthorized user runs `pds-ingress-client` with `--weblogs`, the CloudWatch log submission would spend ~2 minutes retrying 9–10 times on 401/403 responses before giving up. This produced confusing output (dozens of "Backing off..." lines) and significantly delayed client exit — even in cases where 0 files were processed (empty directory or nonexistent path), where no auth error was shown at all.

Changes in `log_util.py`:

- Add `_is_auth_error()` predicate that identifies non-retryable 401/403 `HTTPError`s
- Wire it as `giveup=` on the `send_log_events_to_cloud_watch` backoff decorator so auth failures bail immediately instead of retrying for up to 120s
- Handle the propagated error in `flush()` with a clear user-facing warning: _"Skipping CloudWatch log submission: not authorized to access the log endpoint (401). Session logs were not uploaded."_
- Guard `err.response.text` access against `None` to prevent `AttributeError` when an `HTTPError` carries no response object

### 🤖 AI Assistance Disclosure
- [ ] No AI assistance used
- [ ] AI used for light assistance (e.g., suggestions, refactoring, documentation help, minor edits)
- [ ] AI used for moderate content generation (AI generated some code or logic, but the developer authored or heavily revised the majority)
- [x] AI generated substantial portions of this code

Estimated % of code influenced by AI: 90%

## ⚙️ Test Data and/or Report

No automated tests added for this change. Manual verification via the three cases documented in #368:

- **Case U1** (unauthorized, directory with files): Previously ~2 min of backoff output after the 401 error; now exits immediately with a single warning.
- **Case U2** (unauthorized, empty directory): Previously silent "success" followed by ~2 min of backoff; now shows the warning and exits cleanly.
- **Case U3** (unauthorized, nonexistent directory): Same improvement as U2.

## ♻️ Related Issues

Resolves second bullet point of "Expected behavior" of #368

> 🤖 Generated with [Claude Code](https://claude.ai/claude-code)

## 🤓 Reviewer Checklist

*Reviewers: Please verify the following before approving this pull request.*

### Documentation and PR Content
- [ ] **Documentation:** README, Wiki, or inline documentation (Sphinx, Javadoc, Docstrings) have been updated to reflect these changes.
- [ ] **Issue Traceability:** The PR is linked to a valid GitHub Issue
- [ ] **PR Title:** The PR title is "user-friendly" clearly identifying what is being fixed or the new feature being added, that if you saw it in the Release Notes for a tool, you would be able to get the gist of what was done.

### Security & Quality
- [ ] **SonarCloud:** Confirmed no new High or Critical security findings.
- [ ] **Secrets Detection:** Verified that the Secrets Detection scan passed and no sensitive information (keys, tokens, PII) is exposed.
- [ ] **Code Quality:** Code follows organization style guidelines and best practices for the specific language (e.g., PEP 8, Google Java Style).

### Testing & Validation
- [ ] **Test Accuracy:** Verified that test data is accurate, representative of real-world PDS4 scenarios, and sufficient for the logic being tested.
- [ ] **Coverage:** Automated tests cover new logic and edge cases.
- [ ] **Local Verification:** (If applicable) Successfully built and ran the changes in a local or staging environment.

### Maintenance
- [ ] **Backward Compatibility:** Confirmed that these changes do not break existing downstream dependencies or API contracts (or that breaking changes are clearly documented).
