### PR TITLE
Clarify output for unauthorized users

### DIFF
--- a/src/pds/ingress/client/pds_ingress_client.py
+++ b/src/pds/ingress/client/pds_ingress_client.py
@@ -146,6 +146,36 @@ def perform_ingress(request_batches, node_id, force_overwrite, api_gateway_confi
         return  # return so we can still output a report file
 
 
+def check_authorization(node_id, api_gateway_config):
+    """
+    Performs an early authorization check by making a minimal test request
+    to the API Gateway. This ensures that unauthorized users receive a clear
+    error message even when uploading empty directories or nonexistent files.
+
+    Parameters
+    ----------
+    node_id : str
+        The PDS Node Identifier to associate with the authorization check.
+    api_gateway_config : dict
+        Dictionary containing configuration details for the API Gateway instance.
+
+    Notes
+    -----
+    This function will exit the program if authorization fails, displaying
+    the appropriate error message via the existing error handling in
+    request_batch_for_ingress.
+
+    """
+    global BEARER_TOKEN
+
+    logger = get_logger("check_authorization")
+    logger.info("No files found for ingress. Verifying authorization...")
+
+    # Make a test request with an empty batch to trigger authorization check
+    # If unauthorized, request_batch_for_ingress will handle the error and exit
+    request_batch_for_ingress([], 0, node_id, False, api_gateway_config)
+
+
 def _process_batch(batch_index, request_batch, node_id, force_overwrite, api_gateway_config, total_pbar):
     """
     Performs the steps to process a single batch of ingress requests.
@@ -939,9 +969,28 @@ def main(args):
     if nonexistent_paths:
         for p in nonexistent_paths:
             logger.warning(Color.yellow("Path does not exist and will be skipped: %s"), p)
-        if not resolved_ingress_paths:
-            logger.error("No valid ingress paths found. Exiting.")
-            sys.exit(1)
+
+    # If no valid paths were found, check authorization before exiting
+    # This ensures unauthorized users get a clear error message even when
+    # uploading empty directories or nonexistent files
+    if not resolved_ingress_paths:
+        if not args.dry_run:
+            # Authenticate and check authorization
+            cognito_config = config["COGNITO"]
+
+            if not cognito_config["username"] and cognito_config["password"]:
+                raise ValueError("Username and Password must be specified in the COGNITO portion of the INI config")
+
+            authentication_result = AuthUtil.perform_cognito_authentication(cognito_config)
+            BEARER_TOKEN = AuthUtil.create_bearer_token(authentication_result)
+
+            # Perform authorization check with empty batch
+            # If unauthorized, this will display the clear error message and exit
+            check_authorization(args.node, config["API_GATEWAY"])
+
+        # If we reach here, user is authorized but there are no files to upload
+        logger.error("No valid ingress paths found. Exiting.")
+        sys.exit(1)
 
     # Initialize the summary table, and populate the "unprocessed" table the set
     # of resolved ingress paths

--- a/src/pds/ingress/client/pds_ingress_client.py
+++ b/src/pds/ingress/client/pds_ingress_client.py
@@ -169,9 +169,9 @@ def check_authorization(node_id, api_gateway_config):
     logger = get_logger("check_authorization")
     logger.info("No files found for ingress. Verifying authorization...")
 
-    # Make a test request with an empty batch to trigger authorization check
-    # If unauthorized, request_batch_for_ingress will handle the error and exit
-    request_batch_for_ingress([], 0, node_id, False, api_gateway_config)
+    # Make a test request with an empty batch to trigger authorization check.
+    # Use the undecorated function to bypass retries and fail fast.
+    request_batch_for_ingress.__wrapped__([], 0, node_id, False, api_gateway_config, request_timeout=15)
 
 
 def _process_batch(batch_index, request_batch, node_id, force_overwrite, api_gateway_config, total_pbar):
@@ -388,7 +388,7 @@ def _prepare_batch_for_ingress(ingress_path_batch, prefix, batch_index, batch_pb
 
 
 @backoff.on_exception(backoff.expo, Exception, max_time=120, on_backoff=backoff_handler, logger=None)
-def request_batch_for_ingress(request_batch, batch_index, node_id, force_overwrite, api_gateway_config):
+def request_batch_for_ingress(request_batch, batch_index, node_id, force_overwrite, api_gateway_config, request_timeout=600):
     """
     Submits a batch of ingress requests to the PDS Ingress App API.
 
@@ -407,6 +407,8 @@ def request_batch_for_ingress(request_batch, batch_index, node_id, force_overwri
     api_gateway_config : dict
         Dictionary or dictionary-like containing key/value pairs used to
         configure the API Gateway endpoint url.
+    request_timeout : int, optional
+        Request timeout in seconds.
 
     Returns
     -------
@@ -445,7 +447,7 @@ def request_batch_for_ingress(request_batch, batch_index, node_id, force_overwri
     # Simulate a random failure for the batch request if configured to do so
     with simulate_batch_request_failure(api_gateway_url.split("?")[0]):
         response = requests.post(
-            api_gateway_url, params=params, data=json.dumps(request_batch), headers=headers, timeout=600
+            api_gateway_url, params=params, data=json.dumps(request_batch), headers=headers, timeout=request_timeout
         )
 
     elapsed_time = time.time() - start_time
@@ -976,7 +978,7 @@ def main(args):
             # Authenticate and check authorization
             cognito_config = config["COGNITO"]
 
-            if not cognito_config["username"] and cognito_config["password"]:
+            if not cognito_config["username"] or not cognito_config["password"]:
                 raise ValueError("Username and Password must be specified in the COGNITO portion of the INI config")
 
             authentication_result = AuthUtil.perform_cognito_authentication(cognito_config)

--- a/src/pds/ingress/client/pds_ingress_client.py
+++ b/src/pds/ingress/client/pds_ingress_client.py
@@ -166,8 +166,6 @@ def check_authorization(node_id, api_gateway_config):
     request_batch_for_ingress.
 
     """
-    global BEARER_TOKEN
-
     logger = get_logger("check_authorization")
     logger.info("No files found for ingress. Verifying authorization...")
 

--- a/src/pds/ingress/client/pds_ingress_client.py
+++ b/src/pds/ingress/client/pds_ingress_client.py
@@ -72,6 +72,26 @@ MANIFEST = dict()
 """Stores the file ingress manifest within memory"""
 
 
+def _authenticate(cognito_config):
+    """
+    Performs Cognito authentication and returns authentication result with bearer token.
+
+    Parameters
+    ----------
+    cognito_config : dict
+        Dictionary containing Cognito configuration details.
+
+    Returns
+    -------
+    tuple
+        A tuple containing (authentication_result, bearer_token).
+
+    """
+    authentication_result = AuthUtil.perform_cognito_authentication(cognito_config)
+    bearer_token = AuthUtil.create_bearer_token(authentication_result)
+    return authentication_result, bearer_token
+
+
 def prepare_batches(batched_ingress_paths, prefix):
     """
     Prepares each batch of files for ingress in parallel via the joblib library.
@@ -981,8 +1001,7 @@ def main(args):
             if not cognito_config["username"] or not cognito_config["password"]:
                 raise ValueError("Username and Password must be specified in the COGNITO portion of the INI config")
 
-            authentication_result = AuthUtil.perform_cognito_authentication(cognito_config)
-            BEARER_TOKEN = AuthUtil.create_bearer_token(authentication_result)
+            _, BEARER_TOKEN = _authenticate(cognito_config)
 
             # Perform authorization check with empty batch
             # If unauthorized, this will display the clear error message and exit
@@ -1057,12 +1076,10 @@ def main(args):
         cognito_config = config["COGNITO"]
 
         # TODO: add support for command-line username/password?
-        if not cognito_config["username"] and cognito_config["password"]:
+        if not cognito_config["username"] or not cognito_config["password"]:
             raise ValueError("Username and Password must be specified in the COGNITO portion of the INI config")
 
-        authentication_result = AuthUtil.perform_cognito_authentication(cognito_config)
-
-        BEARER_TOKEN = AuthUtil.create_bearer_token(authentication_result)
+        authentication_result, BEARER_TOKEN = _authenticate(cognito_config)
 
         # Set the bearer token on the CloudWatchHandler singleton, so it can
         # be used to authenticate submissions to the CloudWatch Logs API endpoint

--- a/tests/pds/ingress/client/__init__.py
+++ b/tests/pds/ingress/client/__init__.py
@@ -1,0 +1,1 @@
+# Tests for pds-ingress-client

--- a/tests/pds/ingress/client/test_authorization_check.py
+++ b/tests/pds/ingress/client/test_authorization_check.py
@@ -121,3 +121,4 @@ class TestAuthorizationCheck:
         assert "Authorization" in headers
         assert headers["Authorization"] == "mock-bearer-token"
         assert headers["content-type"] == "application/json"
+        assert call_args[1]["timeout"] == 15

--- a/tests/pds/ingress/client/test_authorization_check.py
+++ b/tests/pds/ingress/client/test_authorization_check.py
@@ -11,7 +11,6 @@ from unittest.mock import MagicMock
 from unittest.mock import patch
 
 import pytest
-
 from pds.ingress.client.pds_ingress_client import check_authorization
 
 

--- a/tests/pds/ingress/client/test_authorization_check.py
+++ b/tests/pds/ingress/client/test_authorization_check.py
@@ -5,7 +5,6 @@ These tests verify that unauthorized users receive clear error messages
 even when attempting to upload empty directories or nonexistent files.
 """
 import json
-import sys
 from http import HTTPStatus
 from unittest.mock import MagicMock
 from unittest.mock import patch

--- a/tests/pds/ingress/client/test_authorization_check.py
+++ b/tests/pds/ingress/client/test_authorization_check.py
@@ -1,0 +1,124 @@
+"""
+Tests for early authorization check functionality in pds_ingress_client.
+
+These tests verify that unauthorized users receive clear error messages
+even when attempting to upload empty directories or nonexistent files.
+"""
+import json
+import sys
+from http import HTTPStatus
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from pds.ingress.client.pds_ingress_client import check_authorization
+
+
+class TestAuthorizationCheck:
+    """Test suite for the check_authorization function."""
+
+    @pytest.fixture
+    def api_gateway_config(self):
+        """Fixture providing mock API Gateway configuration."""
+        return {
+            "url_template": "https://{id}.execute-api.{region}.amazonaws.com/{stage}/{resource}",
+            "id": "test-api-id",
+            "region": "us-west-2",
+            "stage": "dev",
+        }
+
+    @patch("pds.ingress.client.pds_ingress_client.requests.post")
+    @patch("pds.ingress.client.pds_ingress_client.BEARER_TOKEN", "mock-bearer-token")
+    def test_check_authorization_unauthorized_returns_401(self, mock_post, api_gateway_config):
+        """
+        Test that check_authorization properly handles 401 Unauthorized response.
+
+        When a user is not authorized, the API returns 401 and the function
+        should exit with clear error messaging.
+        """
+        # Mock the API response for unauthorized user
+        mock_response = MagicMock()
+        mock_response.status_code = HTTPStatus.UNAUTHORIZED
+        mock_response.reason = "Unauthorized"
+        mock_post.return_value = mock_response
+
+        # Verify that sys.exit(1) is called for unauthorized users
+        with pytest.raises(SystemExit) as exc_info:
+            check_authorization("eng", api_gateway_config)
+
+        assert exc_info.value.code == 1
+        mock_post.assert_called_once()
+
+    @patch("pds.ingress.client.pds_ingress_client.requests.post")
+    @patch("pds.ingress.client.pds_ingress_client.BEARER_TOKEN", "mock-bearer-token")
+    def test_check_authorization_forbidden_returns_403(self, mock_post, api_gateway_config):
+        """
+        Test that check_authorization properly handles 403 Forbidden response.
+
+        When a user's network is not authorized, the API returns 403 and the
+        function should exit with clear error messaging.
+        """
+        # Mock the API response for forbidden access
+        mock_response = MagicMock()
+        mock_response.status_code = HTTPStatus.FORBIDDEN
+        mock_response.reason = "Forbidden"
+        mock_post.return_value = mock_response
+
+        # Verify that sys.exit(1) is called for forbidden users
+        with pytest.raises(SystemExit) as exc_info:
+            check_authorization("eng", api_gateway_config)
+
+        assert exc_info.value.code == 1
+        mock_post.assert_called_once()
+
+    @patch("pds.ingress.client.pds_ingress_client.requests.post")
+    @patch("pds.ingress.client.pds_ingress_client.BEARER_TOKEN", "mock-bearer-token")
+    def test_check_authorization_authorized_returns_200(self, mock_post, api_gateway_config):
+        """
+        Test that check_authorization succeeds for authorized users.
+
+        When a user is properly authorized, the API returns 200 with an empty
+        response batch, and the function should return normally without error.
+        """
+        # Mock the API response for authorized user
+        mock_response = MagicMock()
+        mock_response.status_code = HTTPStatus.OK
+        mock_response.json.return_value = []  # Empty batch response
+        mock_post.return_value = mock_response
+
+        # Should not raise any exception or exit
+        check_authorization("eng", api_gateway_config)
+
+        # Verify the request was made with an empty batch
+        mock_post.assert_called_once()
+        call_args = mock_post.call_args
+
+        # Verify empty batch was sent
+        request_body = json.loads(call_args[1]["data"])
+        assert request_body == []
+
+    @patch("pds.ingress.client.pds_ingress_client.requests.post")
+    @patch("pds.ingress.client.pds_ingress_client.BEARER_TOKEN", "mock-bearer-token")
+    def test_check_authorization_sends_proper_headers(self, mock_post, api_gateway_config):
+        """
+        Test that check_authorization sends proper authentication headers.
+
+        Verify that the authorization check includes the bearer token and
+        other required headers in the request.
+        """
+        # Mock the API response
+        mock_response = MagicMock()
+        mock_response.status_code = HTTPStatus.OK
+        mock_response.json.return_value = []
+        mock_post.return_value = mock_response
+
+        check_authorization("eng", api_gateway_config)
+
+        # Verify headers were sent correctly
+        call_args = mock_post.call_args
+        headers = call_args[1]["headers"]
+
+        assert "Authorization" in headers
+        assert headers["Authorization"] == "mock-bearer-token"
+        assert headers["content-type"] == "application/json"


### PR DESCRIPTION
<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->

## 🗒️ Summary
<!--
   Brief summary of changes if not sufficiently described by commit messages.
-->
Add an early authorization check that runs before the main ingress logic, ensuring unauthorized users get a clear error message regardless of what they're trying to upload (e.g., empty directory or incorrect path).

### 🤖 AI Assistance Disclosure
- [ ] No AI assistance used
- [ ] AI used for light assistance (e.g., suggestions, refactoring, documentation help, minor edits)
- [ ] AI used for moderate content generation (AI generated some code or logic, but the developer authored or heavily revised the majority)
- [x] AI generated substantial portions of this code

Estimated % of code influenced by AI: ___ %

## ⚙️ Test Data and/or Report
<!--
   You MUST include one of:
   1. If automated tests, refer to where tests are documented and/or link to separate PR.
   2. If manual tests, show procedure and/or output
   3. If not tested, describe rationale for not including.
-->
Automated tests were written by Claude at `tests/pds/ingress/client/` but not run.

Manual tests were run for cases U1-U3 with success. Some version of this output snippet shows for all unauthorized users, regardless of in/valid paths or empty directories:
```diff
...
Performing Cognito authentication for user csuh
+ Authentication successful
No files found for ingress. Verifying authorization...
----------------------------------------------
- Ingress request failed with HTTP status 401 (Unauthorized)
- You are not authorized to use the ingestion service (401 Unauthorized).
- Your account may not be in the required user group.
- Please contact PDS Engineering for access.
```

## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo that you want to close, don't forget the "magic words":
        - fixes #1
        - fixes #2
        - refs #3
        - resolves #4
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->
Fully resolves #368, which was partially addressed by [PR#374](https://github.com/NASA-PDS/data-upload-manager/pull/374).

## 🤓 Reviewer Checklist

*Reviewers: Please verify the following before approving this pull request.*

### Documentation and PR Content
- [ ] **Documentation:** README, Wiki, or inline documentation (Sphinx, Javadoc, Docstrings) have been updated to reflect these changes.
- [ ] **Issue Traceability:** The PR is linked to a valid GitHub Issue
- [ ] **PR Title:** The PR title is "user-friendly" clearly identifying what is being fixed or the new feature being added, that if you saw it in the Release Notes for a tool, you would be able to get the gist of what was done.

### Security & Quality
- [ ] **SonarCloud:** Confirmed no new High or Critical security findings.
- [ ] **Secrets Detection:** Verified that the Secrets Detection scan passed and no sensitive information (keys, tokens, PII) is exposed.
- [ ] **Code Quality:** Code follows organization style guidelines and best practices for the specific language (e.g., PEP 8, Google Java Style).

### Testing & Validation
- [ ] **Test Accuracy:** Verified that test data is accurate, representative of real-world PDS4 scenarios, and sufficient for the logic being tested.
- [ ] **Coverage:** Automated tests cover new logic and edge cases.
- [ ] **Local Verification:** (If applicable) Successfully built and ran the changes in a local or staging environment.

### Maintenance
- [ ] **Backward Compatibility:** Confirmed that these changes do not break existing downstream dependencies or API contracts (or that breaking changes are clearly documented).
